### PR TITLE
Fix importing multisig tx

### DIFF
--- a/.changeset/odd-bees-yawn.md
+++ b/.changeset/odd-bees-yawn.md
@@ -1,0 +1,5 @@
+---
+'@thorswap-lib/toolbox-cosmos': minor
+---
+
+Fix importing multisig tx

--- a/packages/toolbox-cosmos/src/toolbox/thorchain.ts
+++ b/packages/toolbox-cosmos/src/toolbox/thorchain.ts
@@ -109,6 +109,9 @@ const importMultisigTx = async (cosmosSdk: cosmosclient.CosmosSDK, tx: any) => {
   try {
     registerDespositCodecs();
     registerSendCodecs();
+    if (typeof tx === 'string') {
+      tx = JSON.parse(tx);
+    }
     const messages = tx.body.messages.map((message: any) =>
       (message['@type'] as string).endsWith('MsgSend')
         ? types.types.MsgSend.fromObject(message)


### PR DESCRIPTION
Fix importing multisig transaction.

Cause: right now, in the frontend, we are passing the stringified version of the tx object. This PR allows for passing both, the stringified version and the transaction object itself.