### PR TITLE
fix: vite-playground Send

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "scripts": {
-    "bootstrap": "rm --rf node_modules; pnpm install; pnpm build",
+    "bootstrap": "rm -rf node_modules; pnpm install; pnpm build",
     "build": "turbo run build --token=turbotoken-oss-europe1",
     "build:vite": "turbo run build-playground --token=turbotoken-oss-europe1 --concurrency=30",
     "preview:vite": "turbo run preview-playground --token=turbotoken-oss-europe1 --concurrency=30",


### PR DESCRIPTION
I am working on the KeepKey integration with @BitHighlander and noticed some funkiness when trying `Send` with multiple supported wallet types.

The problems were:
1) the controlled component wouldn't allow a user to freely type an input amount
2) the assetAmount that was ultimately passed to `sdkClient.transfer` always had a value of 1 decimal (this usually resulted in a value of 0 being passed to the wallet to sign)
3) the bootstrap script had an extra `-`

**Broken:**
<img width="937" alt="Screenshot 2023-08-23 at 12 17 08" src="https://github.com/thorswap/SwapKit/assets/37815163/20f8366a-c8a2-4300-bc3f-673fe2bb32e0">

**Fixed: (https://etherscan.io/tx/0x6325245fada51110bb96f633da21d208e623b2a323901d90802bb02538785d59)**
<img width="937" alt="Screenshot 2023-08-23 at 15 23 26" src="https://github.com/thorswap/SwapKit/assets/37815163/da07176e-4abe-4285-9727-c7eb7c562fd0">
