### PR TITLE
feat: add keepkey

### DIFF
--- a/apps/vite-playground/package.json
+++ b/apps/vite-playground/package.json
@@ -5,6 +5,7 @@
     "@thorswap-lib/evm-web3-wallets": "workspace:*",
     "@thorswap-lib/keplr": "workspace:*",
     "@thorswap-lib/keystore": "workspace:*",
+    "@thorswap-lib/keepkey": "workspace:*",
     "@thorswap-lib/ledger": "workspace:*",
     "@thorswap-lib/swapkit-api": "workspace:*",
     "@thorswap-lib/swapkit-core": "workspace:*",

--- a/apps/vite-playground/vite.config.ts
+++ b/apps/vite-playground/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       '@thorswap-lib/toolbox-cosmos': resolve('../../packages/toolboxes/toolbox-cosmos/src'),
       '@thorswap-lib/toolbox-utxo': resolve('../../packages/toolboxes/toolbox-utxo/src'),
       '@thorswap-lib/types': resolve('../../packages/swapkit/types/src'),
+      '@thorswap-lib/keepkey': resolve('../../packages/wallets/keepkey/src'),
       '@thorswap-lib/trezor': resolve('../../packages/wallets/trezor/src'),
       '@thorswap-lib/xdefi': resolve('../../packages/wallets/xdefi/src'),
 


### PR DESCRIPTION
(WIP)
ADD KEEPKEY

Chain Support
```| chain            | status |
| ---------------- | ------ |
| BTC              | ❓     |
| LTC              | ❓    |
| BCH              | ❓     |
| DOGE             | ❓    |
| ETH              |   ✅  |
| AVAX             |❓     |
| BSC              | ❓     |
| COSMOS (ATOM)    | ❓     |
| BNB              | ❓     |
| THORCHAIN (RUNE) | ❓     |
```
Notes:

Feature Integration keepkey via KeepKey-sdk

**Pairing:**
All applications wishing to communicate with the KeepKey bridge must pair. This process involves the application requesting a pairing, the user approving it in the application, and an apiKey being issued to that app. The app then stores this apiKey for further connections.

![Pairing Screenshot](https://github.com/thorswap/SwapKit/assets/4935895/84383845-a64c-42a5-9fba-f97456e533ed.png)

**Auto-launch:**
The app requires the KeepKey bridge to be running at all times. If KeepKey Desktop is not running, it will be auto-launched.

![Auto-launch Screenshot](https://github.com/thorswap/SwapKit/assets/4935895/964aa6c0-df05-4ca9-80e1-d8db31686dd3.png)

If the bridge still fails to launch, then the user does not have KeepKey Desktop installed and is prompted to go to [keepkey.com/get-started](https://keepkey.com/get-started) to install it.


links
* [keepkey](https://www.keepkey.com/)
* [keepkey-sdk](https://medium.com/@highlander_35968/building-on-the-keepkey-sdk-2023fda41f38)
* [shapeshift](https://github.com/shapeshift/web)

ShapeShift is fully OSS and has working examples for all these assets and can be used a reference


Known Issues:

may contain numerous bugs related to tx signing
* Rune native sends have formatting issues KeepKey desktop side, will require update

Bugs in playground that will need to be addressed before continued development

* unable to to pair more then 1 asset a time, unable to test swapping or actions requiring more then 1 chain selected
* amount is failing to be passed into the transfer function (observed in both trezor and keepkey)
* amount text entry very finicky and only partially working on sends

