### PR TITLE
Update TC mainnet ID for Wallet Connect

### DIFF
--- a/packages/wallets/wc/src/constants.ts
+++ b/packages/wallets/wc/src/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_RELAY_URL = 'wss://relay.walletconnect.com';
 export const ETHEREUM_MAINNET_ID = 'eip155:1';
 export const BSC_MAINNET_ID = 'eip155:56';
 export const AVALACHE_MAINNET_ID = 'eip155:43114';
-export const THORCHAIN_MAINNET_ID = 'cosmos:thorchain';
+export const THORCHAIN_MAINNET_ID = 'cosmos:thorchain-mainnet-v1';
 export const BINANCE_MAINNET_ID = 'cosmos:Binance-Chain-Tigris';
 
 export const DEFAULT_LOGGER = 'debug';


### PR DESCRIPTION
The mainnet ID of THORChain for WC was wrong. 

The following chains are supported by Wallet Connect, but not by SwapKit:
- Maya: `cosmos:mayachain-mainnet-v1`
- Gaia: `cosmos:cosmoshub-4`
- Kujira: `cosmos:kaiyo-1`
- Arbitrum: `eip155:42161`
- Optimism: `eip155:10`
- Polygon: `eip155:137`


BNB chain is in the code, but is not supported by wallet connect. 