### PR TITLE
Kujira: ignore FACTORY tokens, include USK

### DIFF
--- a/packages/swapkit/helpers/src/helpers/asset.ts
+++ b/packages/swapkit/helpers/src/helpers/asset.ts
@@ -5,7 +5,12 @@ import { RequestClient } from '../index.ts';
 
 const getDecimalMethodHex = '0x313ce567';
 
-export type CommonAssetString = 'MAYA.MAYA' | 'ETH.THOR' | 'ETH.vTHOR' | Chain;
+export type CommonAssetString =
+  | 'MAYA.MAYA'
+  | 'ETH.THOR'
+  | 'ETH.vTHOR'
+  | `${Chain.Kujira}.USK`
+  | Chain;
 
 const getContractDecimals = async ({ chain, to }: { chain: EVMChain; to: string }) => {
   try {
@@ -123,6 +128,9 @@ export const getCommonAssetInfo = (
       return { identifier: 'MAYA.CACAO', decimal: BaseDecimal.MAYA };
     case 'MAYA.MAYA':
       return { identifier: 'MAYA.MAYA', decimal: 4 };
+
+    case `${Chain.Kujira}.USK`:
+      return { identifier: `${Chain.Kujira}.USK`, decimal: 6 };
 
     case Chain.Kujira:
     case Chain.Arbitrum:

--- a/packages/toolboxes/cosmos/src/toolbox/BaseCosmosToolbox.ts
+++ b/packages/toolboxes/cosmos/src/toolbox/BaseCosmosToolbox.ts
@@ -34,6 +34,9 @@ export const getAssetFromDenom = async (denom: string, amount: string) => {
     case 'ukuji':
     case 'kuji':
       return AssetValue.fromChainOrSignature(Chain.Kujira, parseInt(amount) / 1e6);
+    case 'FACTORY/KUJIRA1QK00H5ATUTPSV900X202PXX42NPJR9THG58DNQPA72F2P7M2LUASE444A7/UUSK':
+      // USK on Kujira
+      return AssetValue.fromChainOrSignature(`${Chain.Kujira}.USK`, parseInt(amount) / 1e6);
 
     default:
       return AssetValue.fromString(denom, parseInt(amount) / 1e8);

--- a/packages/toolboxes/cosmos/src/toolbox/kujira.ts
+++ b/packages/toolboxes/cosmos/src/toolbox/kujira.ts
@@ -65,10 +65,7 @@ export const KujiraToolbox = ({ server }: ToolboxParams = {}): KujiraToolboxType
               return true;
             }
             // exclude all other FACTORY tokens
-            if (denom.startsWith('FACTORY')) {
-              return false;
-            }
-            return true;
+            return !denom.startsWith('FACTORY');
           })
           .map(({ denom, amount }) => getAssetFromDenom(denom, amount)),
       );


### PR DESCRIPTION
Kujira: `getBalance()`
- ignore all FACTORY tokens (except USK)
  - to fix the error: _`Invalid identifier: FACTORY/KUJIRA1QK00H5ATUTPSV900X202PXX42NPJR9THG58DNQPA72F2P7M2LUASE444A7/UUSK. Expected format: <Chain>.<Ticker> or <Chain>.<Ticker>-<ContractAddress>`_
- USK `FACTORY/KUJIRA1QK00H5ATUTPSV900X202PXX42NPJR9THG58DNQPA72F2P7M2LUASE444A7/UUSK` will be parsed as `KUJI.USK` (pool is available on MAYA)
