### PR TITLE
User rejected: error key core_transaction_user_rejected

### DIFF
--- a/packages/swapkit/core/src/client/index.ts
+++ b/packages/swapkit/core/src/client/index.ts
@@ -321,13 +321,16 @@ export class SwapKitCore<T = ''> {
       const isInsufficientFunds = errorMessage?.includes('insufficient funds');
       const isGas = errorMessage?.includes('gas');
       const isServer = errorMessage?.includes('server');
+      const isUserRejected = errorMessage?.includes('user rejected');
       const errorKey: ErrorKeys = isInsufficientFunds
         ? 'core_transaction_deposit_insufficient_funds_error'
         : isGas
           ? 'core_transaction_deposit_gas_error'
           : isServer
             ? 'core_transaction_deposit_server_error'
-            : 'core_transaction_deposit_error';
+            : isUserRejected
+              ? 'core_transaction_user_rejected'
+              : 'core_transaction_deposit_error';
 
       throw new SwapKitError(errorKey, error);
     }

--- a/packages/swapkit/helpers/src/modules/swapKitError.ts
+++ b/packages/swapkit/helpers/src/modules/swapKitError.ts
@@ -47,7 +47,8 @@ const errorMessages = {
   core_transaction_deposit_insufficient_funds_error: 10311,
   core_transaction_deposit_gas_error: 10312,
   core_transaction_invalid_sender_address: 10313,
-  core_transaction_deposit_server_error: 10313,
+  core_transaction_deposit_server_error: 10314,
+  core_transaction_user_rejected: 10315,
 
   /**
    * Wallets


### PR DESCRIPTION
Currently when the user rejects the `deposit` it shows: `core_transaction_deposit_error`
![image](https://github.com/thorswap/SwapKit/assets/3694800/f690a15f-5033-4d6e-a281-7cac8aa82d04)

Therefore I added the check for the 'user rejected' phrase, to show a better error message in the UI.

I only tested this with XDEFI, but should be similar for other wallets.