### PR TITLE
Fix Type for streamingSwap.fees

### DIFF
--- a/packages/swapkit/api/src/types/quote.ts
+++ b/packages/swapkit/api/src/types/quote.ts
@@ -178,7 +178,7 @@ export type QuoteRoute = {
   transaction?: any;
   streamingSwap?: {
     estimatedTime: number;
-    fees: { [k: string]: Fees[] };
+    fees: Fees;
     expectedOutput: string;
     expectedOutputMaxSlippage: string;
     expectedOutputUSD: string;


### PR DESCRIPTION
The type for "streamingSwap.fees" seems to be incorrect, I guess it should be just

`fees: Fees;`

(or `fees: { [k: string]: FeeItem[] };`, but I guess just "Fees" makes more sense?)

<img width="888" alt="CleanShot 2024-03-27 at 10 17 30@2x" src="https://github.com/thorswap/SwapKit/assets/99530800/7d3546ec-b4b6-494e-aa40-f0e3eda41400">
