### PR TITLE
fix: remove getBalance from methodsToWrap

### DIFF
--- a/.changeset/tender-needles-repair.md
+++ b/.changeset/tender-needles-repair.md
@@ -1,0 +1,5 @@
+---
+"@swapkit/helpers": patch
+---
+
+remove getBalance from methodsToWrap

--- a/packages/swapkit/helpers/src/helpers/web3wallets.ts
+++ b/packages/swapkit/helpers/src/helpers/web3wallets.ts
@@ -59,7 +59,6 @@ const methodsToWrap = [
   "call",
   "sendTransaction",
   "transfer",
-  "getBalance",
   "isApproved",
   "approvedAmount",
   "EIP1193SendTransaction",


### PR DESCRIPTION
Removed getBalance from the network switch wrapping.

As discussed in https://discord.com/channels/831398059484250142/1142087706512474142/1231153101915033671 the `wrapMethodWithNetworkSwitch` is not called at the moment.



