### PR TITLE
fix: split symbol with multiple dashes

### DIFF
--- a/.changeset/khaki-kangaroos-destroy.md
+++ b/.changeset/khaki-kangaroos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@swapkit/helpers": patch
+---
+
+fix: split symbol with multiple dashes

--- a/packages/swapkit/helpers/src/helpers/__tests__/asset.test.ts
+++ b/packages/swapkit/helpers/src/helpers/__tests__/asset.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { BaseDecimal, Chain } from "@swapkit/helpers";
 
-import { getAssetType, getDecimal } from "../asset.ts";
+import { assetFromString, getAssetType, getDecimal } from "../asset.ts";
 
 const tickerMap: Record<string, string> = {
   [Chain.THORChain]: "RUNE",
@@ -171,5 +171,31 @@ describe("getDecimal", () => {
       },
       { retry: 3 },
     );
+  });
+});
+
+describe("assetFromString", () => {
+  test("should return the correct object", () => {
+    const assetString = "THOR.RUNE";
+    const result = assetFromString(assetString);
+
+    expect(result).toEqual({
+      chain: Chain.THORChain,
+      symbol: "RUNE",
+      ticker: "RUNE",
+      synth: false,
+    });
+  });
+
+  test("should return the correct object for multiple dashes", () => {
+    const assetString = "ETH.PENDLE-LPT-0x1234";
+    const result = assetFromString(assetString);
+
+    expect(result).toEqual({
+      chain: Chain.Ethereum,
+      symbol: "PENDLE-LPT-0x1234",
+      ticker: "PENDLE-LPT",
+      synth: false,
+    });
   });
 });

--- a/packages/swapkit/helpers/src/helpers/asset.ts
+++ b/packages/swapkit/helpers/src/helpers/asset.ts
@@ -36,7 +36,8 @@ const getContractDecimals = async ({ chain, to }: { chain: EVMChain; to: string 
 
 const getETHAssetDecimal = (symbol: string) => {
   if (symbol === Chain.Ethereum) return BaseDecimal.ETH;
-  const [, address] = symbol.split("-");
+  const splitSymbol = symbol.split("-");
+  const address = splitSymbol.length === 1 ? undefined : splitSymbol[splitSymbol.length - 1];
 
   return address?.startsWith("0x")
     ? getContractDecimals({ chain: Chain.Ethereum, to: address })
@@ -44,7 +45,8 @@ const getETHAssetDecimal = (symbol: string) => {
 };
 
 const getAVAXAssetDecimal = (symbol: string) => {
-  const [, address] = symbol.split("-");
+  const splitSymbol = symbol.split("-");
+  const address = splitSymbol.length === 1 ? undefined : splitSymbol[splitSymbol.length - 1];
 
   return address?.startsWith("0x")
     ? getContractDecimals({ chain: Chain.Avalanche, to: address.toLowerCase() })
@@ -158,7 +160,12 @@ export const assetFromString = (assetString: string) => {
   const [chain, ...symbolArray] = assetString.split(".") as [Chain, ...(string | undefined)[]];
   const synth = assetString.includes("/");
   const symbol = symbolArray.join(".");
-  const ticker = symbol?.split("-")?.[0];
+  const splitSymbol = symbol?.split("-");
+  const ticker = splitSymbol?.length
+    ? splitSymbol.length === 1
+      ? splitSymbol[0]
+      : splitSymbol.slice(0, -1).join("-")
+    : undefined;
 
   return { chain, symbol, ticker, synth };
 };
@@ -171,7 +178,8 @@ const potentialScamRegex = new RegExp(
 const evmAssetHasAddress = (assetString: string) => {
   const [chain, symbol] = assetString.split(".") as [EVMChain, string];
   if (!EVMChains.includes(chain as EVMChain)) return true;
-  const [, address] = symbol.split("-") as [string, string?];
+  const splitSymbol = symbol.split("-");
+  const address = splitSymbol.length === 1 ? undefined : splitSymbol[splitSymbol.length - 1];
 
   return isGasAsset({ chain: chain as Chain, symbol }) || !!address;
 };

--- a/packages/swapkit/helpers/src/modules/__tests__/assetValue.test.ts
+++ b/packages/swapkit/helpers/src/modules/__tests__/assetValue.test.ts
@@ -155,6 +155,21 @@ describe("AssetValue", () => {
         }),
       );
     });
+    test("creates AssetValue from string with multiple dashes", async () => {
+      const ethPendleLptAsset = await AssetValue.fromIdentifier("ETH.PENDLE-LPT-0x1234");
+
+      expect(ethPendleLptAsset).toEqual(
+        expect.objectContaining({
+          address: "0x1234",
+          chain: Chain.Ethereum,
+          decimal: 18,
+          isGasAsset: false,
+          isSynthetic: false,
+          symbol: "PENDLE-LPT-0x1234",
+          ticker: "PENDLE-LPT",
+        }),
+      );
+    });
   });
 
   describe("fromString", () => {
@@ -171,6 +186,22 @@ describe("AssetValue", () => {
           isSynthetic: false,
           symbol: "ASDF-1234",
           ticker: "ASDF",
+        }),
+      );
+    });
+    test("creates AssetValue from string with multiple dashes", async () => {
+      const fakeAvaxAssetString = "AVAX.ASDF-LP-1234";
+      const fakeAvaxAsset = await AssetValue.fromString(fakeAvaxAssetString);
+
+      expect(fakeAvaxAsset).toEqual(
+        expect.objectContaining({
+          address: "1234",
+          chain: Chain.Avalanche,
+          decimal: 18,
+          isGasAsset: false,
+          isSynthetic: false,
+          symbol: "ASDF-LP-1234",
+          ticker: "ASDF-LP",
         }),
       );
     });
@@ -203,16 +234,19 @@ describe("AssetValue", () => {
       const ethString = "ETH.ETH";
       const thorString = "ETH.THOR-0xa5f2211b9b8170f694421f2046281775e8468044";
       const synthThorString = "THOR.ETH.THOR-0xa5f2211b9b8170f694421f2046281775e8468044";
+      const synthDashesString = "THOR.ETH.PENDLE-LPT-0x1234";
 
       const synthETH = await AssetValue.fromUrl(synthETHString);
       const eth = await AssetValue.fromUrl(ethString);
       const thor = await AssetValue.fromUrl(thorString);
       const synthThor = await AssetValue.fromUrl(synthThorString);
+      const synthDashes = await AssetValue.fromUrl(synthDashesString);
 
       expect(synthETH.toString()).toBe("ETH/ETH");
       expect(eth.toString()).toBe("ETH.ETH");
       expect(thor.toString()).toBe("ETH.THOR-0xa5f2211b9b8170f694421f2046281775e8468044");
       expect(synthThor.toString()).toBe("ETH/THOR-0xa5f2211b9b8170f694421f2046281775e8468044");
+      expect(synthDashes.toString()).toBe("ETH/PENDLE-LPT-0x1234");
     });
   });
 
@@ -286,6 +320,25 @@ describe("AssetValue", () => {
           isSynthetic: false,
           symbol: "USDC-1234",
           ticker: "USDC",
+        }),
+      );
+    });
+
+    test("returns safe decimals if string is not in `@swapkit/tokens` lists with multiple dashes", async () => {
+      await AssetValue.loadStaticAssets();
+      const fakeAvaxUSDCAssetString = "AVAX.USDC-LPT-1234";
+      const fakeAvaxUSDCAsset = AssetValue.fromStringSync(fakeAvaxUSDCAssetString);
+
+      expect(fakeAvaxUSDCAsset).toBeDefined();
+      expect(fakeAvaxUSDCAsset).toEqual(
+        expect.objectContaining({
+          address: "1234",
+          chain: Chain.Avalanche,
+          decimal: 18,
+          isGasAsset: false,
+          isSynthetic: false,
+          symbol: "USDC-LPT-1234",
+          ticker: "USDC-LPT",
         }),
       );
     });

--- a/packages/swapkit/helpers/src/modules/assetValue.ts
+++ b/packages/swapkit/helpers/src/modules/assetValue.ts
@@ -287,11 +287,13 @@ function getAssetInfo(identifier: string) {
       : `${isMaya ? Chain.Maya : Chain.THORChain}.${synthSymbol}`;
 
   const [chain, ...rest] = adjustedIdentifier.split(".") as [Chain, string];
-  const [ticker, address] = (isSynthetic ? synthSymbol : rest.join(".")).split("-") as [
-    string,
-    string?,
-  ];
+
   const symbol = isSynthetic ? synthSymbol : rest.join(".");
+  const splitSymbol = symbol.split("-");
+  const ticker = (
+    splitSymbol.length === 1 ? splitSymbol[0] : splitSymbol.slice(0, -1).join("-")
+  ) as string;
+  const address = splitSymbol.length === 1 ? undefined : splitSymbol[splitSymbol.length - 1];
 
   return {
     address: address?.toLowerCase(),


### PR DESCRIPTION
https://discord.com/channels/831398059484250142/1142087706512474142/1231359505267425452

There is a bigger issue with split("-") where you expect the contract address always on index [1]. but this is not the case, because there are assets like PENDLE-LPT-0x123, and other tokens with more dashes in it, or some scam tokens with an URL in it. (see screenshot) 🙈 

![image](https://github.com/thorswap/SwapKit/assets/3694800/a431c90e-4c2e-4ec4-8c37-d585c65525f5)

