### PR TITLE
Fix getDerivationPathFor

### DIFF
--- a/packages/swapkit/helpers/src/helpers/derivationPath.ts
+++ b/packages/swapkit/helpers/src/helpers/derivationPath.ts
@@ -7,27 +7,28 @@ import {
 } from "../types";
 
 type Params = {
-  index: number;
-  chain: Chain;
-  type?: "legacy" | "ledgerLive" | "nativeSegwitMiddleAccount" | "segwit";
-};
+  chain: Chain
+  index: number
+  addressIndex?: number
+  type?: 'legacy' | 'ledgerLive' | 'nativeSegwitMiddleAccount' | 'segwit'
+}
 
 const updatedLastIndex = (path: DerivationPathArray, index: number) => [
   ...path.slice(0, path.length - 1),
   index,
 ];
 
-export function getDerivationPathFor({ chain, index, type }: Params) {
+export function getDerivationPathFor({ chain, index, addressIndex = 0, type }: Params) {
   if (EVMChains.includes(chain as EVMChain)) {
     if (type === "legacy") return [44, 60, 0, index];
-    if (type === "ledgerLive") return [44, 60, index, 0, 0];
+    if (type === "ledgerLive") return [44, 60, index, 0, addressIndex];
     return updatedLastIndex(NetworkDerivationPath[chain], index);
   }
 
   if ([Chain.Bitcoin, Chain.Litecoin].includes(chain)) {
     const chainId = chain === Chain.Bitcoin ? 0 : 2;
 
-    if (type === "nativeSegwitMiddleAccount") return [84, chainId, index, 0, 0];
+    if (type === "nativeSegwitMiddleAccount") return [84, chainId, index, 0, addressIndex];
     if (type === "segwit") return [49, chainId, 0, 0, index];
     if (type === "legacy") return [44, chainId, 0, 0, index];
     return updatedLastIndex(NetworkDerivationPath[chain], index);

--- a/packages/swapkit/helpers/src/helpers/derivationPath.ts
+++ b/packages/swapkit/helpers/src/helpers/derivationPath.ts
@@ -7,11 +7,11 @@ import {
 } from "../types";
 
 type Params = {
-  chain: Chain
-  index: number
-  addressIndex?: number
-  type?: 'legacy' | 'ledgerLive' | 'nativeSegwitMiddleAccount' | 'segwit'
-}
+  chain: Chain;
+  index: number;
+  addressIndex?: number;
+  type?: "legacy" | "ledgerLive" | "nativeSegwitMiddleAccount" | "segwit";
+};
 
 const updatedLastIndex = (path: DerivationPathArray, index: number) => [
   ...path.slice(0, path.length - 1),


### PR DESCRIPTION
I suggest to also add "addressIndex" as an optional parameter for **getDerivationPathFor**, as i just ran into the problem not being able to get the correct derivation path for a Hardware-Wallet:  (addressIndex was "1", but the function assumes addressIndex is always "0")

**Case:**
chain: Chain.Bitcoin
index: 0
type: nativeSegwitMiddleAccount

**Returns:** .............. [84, 0, 0, 0, 0]
**Desired Result:** ... [84, 0, 0, 0, 1]




