### PR TITLE
new release for Talisman

### DIFF
--- a/.changeset/hungry-foxes-crash.md
+++ b/.changeset/hungry-foxes-crash.md
@@ -1,0 +1,5 @@
+---
+"@swapkit/wallets": minor
+---
+
+Add Avalanche to the Talisman supported chains


### PR DESCRIPTION
New release for the Talisman wallet.
Now Talisman wallet is not providing the avalanche chain, it is already exist on SDK but didn't released yet.