### PR TITLE
chore: import modules async or inline

### DIFF
--- a/packages/plugins/chainflip/package.json
+++ b/packages/plugins/chainflip/package.json
@@ -23,7 +23,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/plugin-chainflip",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/plugins/evm/package.json
+++ b/packages/plugins/evm/package.json
@@ -14,7 +14,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/plugin-evm",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/plugins/radix/package.json
+++ b/packages/plugins/radix/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/plugin-radix",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/plugins/thorchain/package.json
+++ b/packages/plugins/thorchain/package.json
@@ -17,7 +17,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/plugin-thorchain",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/api/package.json
+++ b/packages/swapkit/api/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/api",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/contracts/package.json
+++ b/packages/swapkit/contracts/package.json
@@ -8,7 +8,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/contracts",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/core/package.json
+++ b/packages/swapkit/core/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/core",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/core/src/client.ts
+++ b/packages/swapkit/core/src/client.ts
@@ -20,16 +20,9 @@ import {
   type SwapParams,
   type WalletChain,
 } from "@swapkit/helpers";
-import {
-  type TransferParams as CosmosTransferParams,
-  estimateTransactionFee as cosmosTransactionFee,
-  cosmosValidateAddress,
-} from "@swapkit/toolbox-cosmos";
-import { type TransferParams as EVMTransferParams, evmValidateAddress } from "@swapkit/toolbox-evm";
-import { validateAddress as validateRadixAddress } from "@swapkit/toolbox-radix";
-import { validateAddress as solanaValidateAddress } from "@swapkit/toolbox-solana";
-import { substrateValidateAddress } from "@swapkit/toolbox-substrate";
-import { type UTXOTransferParams, utxoValidateAddress } from "@swapkit/toolbox-utxo";
+import type { TransferParams as CosmosTransferParams } from "@swapkit/toolbox-cosmos";
+import type { TransferParams as EVMTransferParams } from "@swapkit/toolbox-evm";
+import type { UTXOTransferParams } from "@swapkit/toolbox-utxo";
 
 import {
   getExplorerAddressUrl as getAddressUrl,
@@ -213,37 +206,56 @@ export function SwapKit<
     ) as ConditionalAssetValueReturn<R>;
   }
 
+  /**
+   * @deprecated - use toolbox directly or use getAddressValidator() function
+   */
   function validateAddress({ address, chain }: { address: string; chain: Chain }) {
+    console.warn(
+      "validateAddress is deprecated - use toolbox directly or import { getAddressValidator } from '@swapkit/core'",
+    );
+
     switch (chain) {
       case Chain.Arbitrum:
       case Chain.Avalanche:
       case Chain.Optimism:
       case Chain.BinanceSmartChain:
       case Chain.Polygon:
-      case Chain.Ethereum:
+      case Chain.Ethereum: {
+        const { evmValidateAddress } = require("@swapkit/toolbox-evm");
         return evmValidateAddress({ address });
+      }
 
       case Chain.Litecoin:
       case Chain.Dash:
       case Chain.Dogecoin:
       case Chain.BitcoinCash:
-      case Chain.Bitcoin:
+      case Chain.Bitcoin: {
+        const { utxoValidateAddress } = require("@swapkit/toolbox-utxo");
         return utxoValidateAddress({ address, chain });
+      }
 
       case Chain.Cosmos:
       case Chain.Kujira:
       case Chain.Maya:
-      case Chain.THORChain:
+      case Chain.THORChain: {
+        const { cosmosValidateAddress } = require("@swapkit/toolbox-cosmos");
         return cosmosValidateAddress({ address, chain });
+      }
 
-      case Chain.Polkadot:
+      case Chain.Polkadot: {
+        const { substrateValidateAddress } = require("@swapkit/toolbox-substrate");
         return substrateValidateAddress({ address, chain });
+      }
 
-      case Chain.Radix:
+      case Chain.Radix: {
+        const { validateRadixAddress } = require("@swapkit/toolbox-radix");
         return validateRadixAddress(address);
+      }
 
-      case Chain.Solana:
+      case Chain.Solana: {
+        const { solanaValidateAddress } = require("@swapkit/toolbox-solana");
         return solanaValidateAddress(address);
+      }
 
       default:
         return false;
@@ -418,7 +430,8 @@ export function SwapKit<
       case Chain.Maya:
       case Chain.Kujira:
       case Chain.Cosmos: {
-        return cosmosTransactionFee(params);
+        const { estimateTransactionFee } = await import("@swapkit/toolbox-cosmos");
+        return estimateTransactionFee(params);
       }
 
       case Chain.Polkadot: {

--- a/packages/swapkit/core/src/helpers/walletAddressValidator.ts
+++ b/packages/swapkit/core/src/helpers/walletAddressValidator.ts
@@ -1,0 +1,51 @@
+import { Chain } from "@swapkit/helpers";
+
+export async function getAddressValidator() {
+  const { cosmosValidateAddress } = await import("@swapkit/toolbox-cosmos");
+  const { evmValidateAddress } = await import("@swapkit/toolbox-evm");
+  const { substrateValidateAddress } = await import("@swapkit/toolbox-substrate");
+  const { utxoValidateAddress } = await import("@swapkit/toolbox-utxo");
+  const { validateAddress: solanaValidateAddress } = await import("@swapkit/toolbox-solana");
+  const { validateAddress: validateRadixAddress } = await import("@swapkit/toolbox-radix");
+
+  return function validateAddress({ address, chain }: { address: string; chain: Chain }) {
+    switch (chain) {
+      case Chain.Arbitrum:
+      case Chain.Avalanche:
+      case Chain.Optimism:
+      case Chain.BinanceSmartChain:
+      case Chain.Polygon:
+      case Chain.Ethereum:
+        return evmValidateAddress;
+
+      case Chain.Litecoin:
+      case Chain.Dash:
+      case Chain.Dogecoin:
+      case Chain.BitcoinCash:
+      case Chain.Bitcoin:
+        return utxoValidateAddress({ address, chain });
+
+      case Chain.Cosmos:
+      case Chain.Kujira:
+      case Chain.Maya:
+      case Chain.THORChain: {
+        return cosmosValidateAddress({ address, chain });
+      }
+
+      case Chain.Polkadot: {
+        return substrateValidateAddress({ address, chain });
+      }
+
+      case Chain.Radix: {
+        return validateRadixAddress;
+      }
+
+      case Chain.Solana: {
+        return solanaValidateAddress;
+      }
+
+      default:
+        return () => false;
+    }
+  };
+}

--- a/packages/swapkit/core/src/index.ts
+++ b/packages/swapkit/core/src/index.ts
@@ -1,5 +1,3 @@
 export * from "@swapkit/api";
 export * from "@swapkit/helpers";
-export { stripToCashAddress } from "@swapkit/toolbox-utxo";
-
 export * from "./client";

--- a/packages/swapkit/helpers/package.json
+++ b/packages/swapkit/helpers/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/helpers",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/sdk/package.json
+++ b/packages/swapkit/sdk/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/sdk",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/tokens/package.json
+++ b/packages/swapkit/tokens/package.json
@@ -9,7 +9,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/tokens",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/swapkit/wallets/package.json
+++ b/packages/swapkit/wallets/package.json
@@ -25,7 +25,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallets",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/cosmos/package.json
+++ b/packages/toolboxes/cosmos/package.json
@@ -27,7 +27,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-cosmos",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/evm/package.json
+++ b/packages/toolboxes/evm/package.json
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-evm",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/radix/package.json
+++ b/packages/toolboxes/radix/package.json
@@ -16,7 +16,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-radix",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/solana/package.json
+++ b/packages/toolboxes/solana/package.json
@@ -16,7 +16,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-solana",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/substrate/package.json
+++ b/packages/toolboxes/substrate/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-substrate",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/toolboxes/utxo/package.json
+++ b/packages/toolboxes/utxo/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/toolbox-utxo",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/coinbase/package.json
+++ b/packages/wallets/coinbase/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-coinbase",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/coinbase/src/signer.ts
+++ b/packages/wallets/coinbase/src/signer.ts
@@ -1,12 +1,7 @@
 import { type CoinbaseWalletProvider, CoinbaseWalletSDK } from "@coinbase/wallet-sdk";
 import type { CoinbaseWalletSDKOptions } from "@coinbase/wallet-sdk/dist/CoinbaseWalletSDK";
 import { Chain, ChainToRPC } from "@swapkit/helpers";
-import {
-  AbstractSigner,
-  type Provider,
-  getProvider,
-  type getToolboxByChain,
-} from "@swapkit/toolbox-evm";
+import { AbstractSigner, type Provider, type getToolboxByChain } from "@swapkit/toolbox-evm";
 
 class CoinbaseMobileSigner extends AbstractSigner {
   #coinbaseProvider: CoinbaseWalletProvider;
@@ -77,7 +72,7 @@ export const getWalletForChain = async ({
       // TODO fix error
       if (!walletProvider) throw new Error("No wallet provider");
 
-      const { getToolboxByChain } = await import("@swapkit/toolbox-evm");
+      const { getToolboxByChain, getProvider } = await import("@swapkit/toolbox-evm");
 
       const provider = getProvider(chain);
 

--- a/packages/wallets/evm-extensions/package.json
+++ b/packages/wallets/evm-extensions/package.json
@@ -12,7 +12,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-evm-extensions",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/evm-extensions/src/index.ts
+++ b/packages/wallets/evm-extensions/src/index.ts
@@ -10,12 +10,7 @@ import {
   prepareNetworkSwitch,
   setRequestClientConfig,
 } from "@swapkit/helpers";
-import {
-  type AVAXToolbox,
-  type BrowserProvider,
-  type Eip1193Provider,
-  getToolboxByChain,
-} from "@swapkit/toolbox-evm";
+import type { AVAXToolbox, BrowserProvider, Eip1193Provider } from "@swapkit/toolbox-evm";
 
 declare const window: {
   ethereum: EthereumWindowProvider;
@@ -66,6 +61,7 @@ export const getWeb3WalletMethods = async ({
   provider: BrowserProvider;
 }) => {
   if (!ethereumWindowProvider) throw new Error("Requested web3 wallet is not installed");
+  const { getToolboxByChain } = await import("@swapkit/toolbox-evm");
 
   const keys = ensureEVMApiKeys({ chain, covalentApiKey, ethplorerApiKey });
   const signer = await provider.getSigner();

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -17,7 +17,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-exodus",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/keepkey/package.json
+++ b/packages/wallets/keepkey/package.json
@@ -19,7 +19,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "react-native": "./src/index.ts",
   "repository": "https://github.com/thorswap/SwapKit.git",
   "scripts": {
     "build": "bun run ./build.ts",

--- a/packages/wallets/keplr/package.json
+++ b/packages/wallets/keplr/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-keplr",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/keystore/package.json
+++ b/packages/wallets/keystore/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-keystore",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/ledger/package.json
+++ b/packages/wallets/ledger/package.json
@@ -29,7 +29,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-ledger",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/ledger/src/clients/utxo.ts
+++ b/packages/wallets/ledger/src/clients/utxo.ts
@@ -7,7 +7,6 @@ import {
   getWalletFormatFor,
 } from "@swapkit/helpers";
 import type { Psbt, UTXOType } from "@swapkit/toolbox-utxo";
-import { Transaction, toCashAddress } from "@swapkit/toolbox-utxo";
 
 import { getLedgerTransport } from "../helpers/getLedgerTransport";
 
@@ -22,6 +21,8 @@ const signUTXOTransaction = async (
   { psbt, inputUtxos, btcApp, derivationPath }: Params,
   options?: Partial<CreateTransactionArg>,
 ) => {
+  const { Transaction } = await import("@swapkit/toolbox-utxo");
+
   const inputs = inputUtxos.map((item) => {
     const utxoTx = Transaction.fromHex(item.txHex || "");
     const splitTx = btcApp.splitTransaction(utxoTx.toHex(), utxoTx.hasWitnesses());
@@ -107,6 +108,8 @@ const BaseLedgerUTXO = ({
         );
       },
       getAddress: async () => {
+        const { toCashAddress } = await import("@swapkit/toolbox-utxo");
+
         await checkBtcAppAndCreateTransportWebUSB(false);
 
         const { bitcoinAddress: address } = await btcApp.getWalletPublicKey(derivationPath, {

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -14,7 +14,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-okx",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/okx/src/helpers.ts
+++ b/packages/wallets/okx/src/helpers.ts
@@ -2,19 +2,14 @@ import {
   Chain,
   ChainId,
   ChainToHexChainId,
+  type EVMChain,
   RPCUrl,
   SwapKitError,
   addEVMWalletNetwork,
   prepareNetworkSwitch,
 } from "@swapkit/helpers";
 import type { GaiaToolbox } from "@swapkit/toolbox-cosmos";
-import {
-  AVAXToolbox,
-  BSCToolbox,
-  BrowserProvider,
-  ETHToolbox,
-  type Eip1193Provider,
-} from "@swapkit/toolbox-evm";
+import type { Eip1193Provider } from "@swapkit/toolbox-evm";
 import type { BTCToolbox, Psbt, UTXOTransferParams } from "@swapkit/toolbox-utxo";
 
 const cosmosTransfer =
@@ -144,10 +139,11 @@ export const getWeb3WalletMethods = async ({
   ethplorerApiKey,
 }: {
   ethereumWindowProvider: Eip1193Provider | undefined;
-  chain: Chain;
+  chain: EVMChain;
   covalentApiKey?: string;
   ethplorerApiKey?: string;
 }) => {
+  const { getToolboxByChain, BrowserProvider } = await import("@swapkit/toolbox-evm");
   if (!ethereumWindowProvider) throw new Error("Requested web3 wallet is not installed");
 
   if (
@@ -165,35 +161,20 @@ export const getWeb3WalletMethods = async ({
 
   const provider = new BrowserProvider(ethereumWindowProvider, "any");
 
-  const toolboxParams = {
+  const toolbox = getToolboxByChain(chain)({
     provider,
     signer: await provider.getSigner(),
     ethplorerApiKey: ethplorerApiKey as string,
     covalentApiKey: covalentApiKey as string,
-  };
-
-  const toolbox =
-    chain === Chain.Ethereum
-      ? ETHToolbox(toolboxParams)
-      : chain === Chain.Avalanche
-        ? AVAXToolbox(toolboxParams)
-        : BSCToolbox(toolboxParams);
+  });
 
   try {
-    chain !== Chain.Ethereum &&
-      (await addEVMWalletNetwork(
-        provider,
-        (
-          toolbox as ReturnType<typeof AVAXToolbox> | ReturnType<typeof BSCToolbox>
-        ).getNetworkParams(),
-      ));
+    if (chain !== Chain.Ethereum && "getNetworkParams" in toolbox) {
+      await addEVMWalletNetwork(provider, toolbox.getNetworkParams());
+    }
   } catch (_error) {
     throw new Error(`Failed to add/switch ${chain} network: ${chain}`);
   }
 
-  return prepareNetworkSwitch<typeof toolbox>({
-    toolbox: { ...toolbox },
-    chainId: ChainToHexChainId[chain],
-    provider,
-  });
+  return prepareNetworkSwitch({ toolbox, provider, chainId: ChainToHexChainId[chain] });
 };

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -15,7 +15,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-phantom",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/phantom/src/index.ts
+++ b/packages/wallets/phantom/src/index.ts
@@ -10,7 +10,6 @@ import {
   setRequestClientConfig,
 } from "@swapkit/helpers";
 import type { SolanaProvider } from "@swapkit/toolbox-solana";
-import { createSolanaTokenTransaction } from "@swapkit/toolbox-solana";
 
 export const PHANTOM_SUPPORTED_CHAINS = [Chain.Bitcoin, Chain.Ethereum, Chain.Solana] as const;
 export type PhantomSupportedChains = (typeof PHANTOM_SUPPORTED_CHAINS)[number];
@@ -65,7 +64,7 @@ async function getWalletMethods<T extends PhantomSupportedChains>({
     }
 
     case Chain.Solana: {
-      const { SOLToolbox } = await import("@swapkit/toolbox-solana");
+      const { createSolanaTokenTransaction, SOLToolbox } = await import("@swapkit/toolbox-solana");
       const provider = phantom?.solana;
       if (!provider?.isPhantom) {
         throw new SwapKitError("wallet_phantom_not_found");

--- a/packages/wallets/polkadotjs/package.json
+++ b/packages/wallets/polkadotjs/package.json
@@ -14,7 +14,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-polkadotjs",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/radix/package.json
+++ b/packages/wallets/radix/package.json
@@ -15,7 +15,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-radix",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/talisman/package.json
+++ b/packages/wallets/talisman/package.json
@@ -15,7 +15,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-talisman",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/talisman/src/helpers.ts
+++ b/packages/wallets/talisman/src/helpers.ts
@@ -10,16 +10,14 @@ import {
   ensureEVMApiKeys,
   prepareNetworkSwitch,
 } from "@swapkit/helpers";
-import {
-  type ARBToolbox,
-  type BASEToolbox,
-  type BSCToolbox,
-  BrowserProvider,
-  type Eip1193Provider,
-  type MATICToolbox,
-  type OPToolbox,
+import type {
+  ARBToolbox,
+  BASEToolbox,
+  BSCToolbox,
+  Eip1193Provider,
+  MATICToolbox,
+  OPToolbox,
 } from "@swapkit/toolbox-evm";
-
 import type { InjectedWindow } from "@swapkit/toolbox-substrate";
 
 declare const window: {
@@ -44,7 +42,7 @@ export const getWeb3WalletMethods = async ({
   covalentApiKey?: string;
   ethplorerApiKey?: string;
 }) => {
-  const { getToolboxByChain } = await import("@swapkit/toolbox-evm");
+  const { BrowserProvider, getToolboxByChain } = await import("@swapkit/toolbox-evm");
 
   if (!ethereumWindowProvider) {
     throw new SwapKitError({

--- a/packages/wallets/trezor/package.json
+++ b/packages/wallets/trezor/package.json
@@ -14,7 +14,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-trezor",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/wc/package.json
+++ b/packages/wallets/wc/package.json
@@ -23,7 +23,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-wc",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/xdefi/package.json
+++ b/packages/wallets/xdefi/package.json
@@ -16,7 +16,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "name": "@swapkit/wallet-xdefi",
-  "react-native": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thorswap/SwapKit.git"

--- a/packages/wallets/xdefi/src/walletHelpers.ts
+++ b/packages/wallets/xdefi/src/walletHelpers.ts
@@ -12,7 +12,7 @@ import {
   WalletOption,
   erc20ABI,
 } from "@swapkit/helpers";
-import { type TransferParams, getDenom } from "@swapkit/toolbox-cosmos";
+import type { TransferParams } from "@swapkit/toolbox-cosmos";
 import type {
   ApproveParams,
   BrowserProvider,
@@ -212,7 +212,7 @@ export function cosmosTransfer({
   rpcUrl?: string;
 }) {
   return async ({ from, recipient, assetValue, memo }: TransferParams) => {
-    const { createSigningStargateClient } = await import("@swapkit/toolbox-cosmos");
+    const { getDenom, createSigningStargateClient } = await import("@swapkit/toolbox-cosmos");
     await window.xfi?.keplr?.enable(chainId);
     // @ts-ignore
     const offlineSigner = window.xfi?.keplr?.getOfflineSignerOnlyAmino(chainId);

--- a/tools/builder/index.ts
+++ b/tools/builder/index.ts
@@ -16,6 +16,7 @@ export async function buildPackage({
     minify: true,
     external,
     sourcemap: "external",
+    splitting: true,
     plugins: [...(plugins || [])],
     ...rest,
   });


### PR DESCRIPTION
+ Change on address validator to export method instead of include in swapkit core as this probably should be done anyway on side of toolbox tx creation (to validate address passed to function)
- Remove `stripCashAddress` from core re-export - it's definitely included in build via `@swapkit/toolbox-utxo` and it should be used from it directly (toolbox is installed with core anyway as it's dependant on UTXOToolbox type)