### PR TITLE
fix: pass in correct sellAsset to chainflip

### DIFF
--- a/packages/plugins/chainflip/src/plugin.ts
+++ b/packages/plugins/chainflip/src/plugin.ts
@@ -139,7 +139,7 @@ function plugin({
       brokerEndpoint: brokerUrl,
       buyAsset,
       recipient,
-      sellAsset,
+      assetValue,
       maxBoostFeeBps,
       chainflipSDKBroker: useChainflipSDKBroker,
     });

--- a/packages/plugins/chainflip/src/plugin.ts
+++ b/packages/plugins/chainflip/src/plugin.ts
@@ -139,7 +139,7 @@ function plugin({
       brokerEndpoint: brokerUrl,
       buyAsset,
       recipient,
-      assetValue,
+      sellAsset: assetValue,
       maxBoostFeeBps,
       chainflipSDKBroker: useChainflipSDKBroker,
     });


### PR DESCRIPTION
Right now sellAsset.set returns an AssetValue but this is not passed to getDepositAddress. This thus receives a value of `0` which is always below the minimum of Chainflip and will throw an error of not meeting minimum amounts.