### PR TITLE
fix incorrect destAsset

### DIFF
--- a/packages/plugins/chainflip/src/plugin.ts
+++ b/packages/plugins/chainflip/src/plugin.ts
@@ -42,7 +42,7 @@ export async function getDepositAddress({
 
       const srcAsset = assetTickerToChainflipAsset.get(sellAsset.ticker);
       const srcChain = chainToChainflipChain.get(sellAsset.chain);
-      const destAsset = assetTickerToChainflipAsset.get(buyAsset.chain);
+      const destAsset = assetTickerToChainflipAsset.get(buyAsset.ticker);
       const destChain = chainToChainflipChain.get(buyAsset.chain);
 
       if (!(srcAsset && srcChain && destAsset && destChain)) {


### PR DESCRIPTION
As of now when you try to swap through chainflip plugin you incorrectly pass the  buyAsset.chain instead of buyAsset.ticker
to get the destAsst

This returns undefined and throws an error in the next lines. Up to now it worked randomly for some assets but it will fail for ARB.ETH or in other cases pass the wrong asset