### PR TITLE
fix/keepkey  config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "packages/core": {
       "name": "@swapkit/core",
-      "version": "4.0.0-beta.16",
+      "version": "4.0.0-beta.17",
       "dependencies": {
         "@swapkit/helpers": "workspace:*",
         "@swapkit/toolboxes": "workspace:*",
@@ -49,7 +49,7 @@
     },
     "packages/helpers": {
       "name": "@swapkit/helpers",
-      "version": "3.0.0-beta.11",
+      "version": "3.0.0-beta.12",
       "dependencies": {
         "ethers": "6.14.3",
         "ts-pattern": "5.7.1",
@@ -62,7 +62,7 @@
     },
     "packages/plugins": {
       "name": "@swapkit/plugins",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@polkadot/keyring": "13.5.1",
         "@polkadot/util": "13.5.1",
@@ -74,7 +74,7 @@
     },
     "packages/sdk": {
       "name": "@swapkit/sdk",
-      "version": "3.0.0-beta.19",
+      "version": "3.0.0-beta.20",
       "dependencies": {
         "@swapkit/core": "workspace:*",
         "@swapkit/plugins": "workspace:*",
@@ -84,7 +84,7 @@
     },
     "packages/toolboxes": {
       "name": "@swapkit/toolboxes",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@cosmjs/amino": "0.33.1",
@@ -130,7 +130,7 @@
     },
     "packages/ui": {
       "name": "@swapkit/ui",
-      "version": "0.1.0-beta.19",
+      "version": "0.1.0-beta.20",
       "dependencies": {
         "@swapkit/core": "workspace:*",
         "@swapkit/plugins": "workspace:*",
@@ -144,7 +144,7 @@
     },
     "packages/wallets": {
       "name": "@swapkit/wallets",
-      "version": "3.0.0-beta.19",
+      "version": "3.0.0-beta.20",
       "dependencies": {
         "@coinbase/wallet-sdk": "4.3.4",
         "@cosmjs/amino": "0.33.1",

--- a/packages/wallets/src/keepkey/index.ts
+++ b/packages/wallets/src/keepkey/index.ts
@@ -44,14 +44,21 @@ export const keepkeyWallet = createWallet({
       derivationPathMap?: Record<Chain, DerivationPathArray>,
     ) {
       const filteredChains = filterSupportedChains({ chains, supportedChains, walletType });
-      const config = SKConfig.get("integrations").keepKey;
+      const pairingInfo = SKConfig.get("integrations").keepKey;
+      if (!pairingInfo) throw new Error("KeepKey config not found");
 
-      if (!config) throw new Error("KeepKey config not found");
+      const initialApiKey = SKConfig.get("apiKeys").keepKey || "1234";
 
       await checkAndLaunch();
 
-      const keepkeyConfig = { ...config, apiKey: SKConfig.get("apiKeys").keepKey };
+      // Conform to the expected { apiKey, pairingInfo } structure
+      const keepkeyConfig = { apiKey: initialApiKey, pairingInfo };
       const keepKeySdk = await KeepKeySdk.create(keepkeyConfig);
+
+      // Persist the new API key via SKConfig after pairing
+      if (keepkeyConfig.apiKey && keepkeyConfig.apiKey !== initialApiKey) {
+        SKConfig.setApiKey("keepKey", keepkeyConfig.apiKey);
+      }
 
       await Promise.all(
         filteredChains.map(async (chain) => {
@@ -84,6 +91,7 @@ async function getWalletMethods({
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.Avalanche:
+    case Chain.Base:
     case Chain.Ethereum: {
       const provider = await getProvider(chain);
       const signer = new KeepKeySigner({ sdk, chain, derivationPath, provider });
@@ -112,7 +120,7 @@ async function getWalletMethods({
   }
 }
 
-// kk-sdk docs: https://medium.com/@highlander_35968/building-on-the-keepkey-sdk-2023fda41f38
+// kk-sdk docs: https://keepkey.com/blog/building_on_the_keepkey_sdk
 // test spec: if offline, launch keepkey-bridge
 async function checkAndLaunch(attempts = 0) {
   if (attempts >= 3) {

--- a/playgrounds/nextjs/src/components/WalletConnectDialog.tsx
+++ b/playgrounds/nextjs/src/components/WalletConnectDialog.tsx
@@ -109,6 +109,7 @@ export const availableChainsByWallet = {
   [WalletOption.KEEPKEY]: [
     Chain.Arbitrum,
     Chain.Avalanche,
+    Chain.Base,
     Chain.BinanceSmartChain,
     Chain.Bitcoin,
     Chain.BitcoinCash,

--- a/playgrounds/nextjs/src/lib/swapKit.ts
+++ b/playgrounds/nextjs/src/lib/swapKit.ts
@@ -36,14 +36,14 @@ export const useSwapKit = () => {
           apiKeys: {
             swapKit: process.env.NEXT_PUBLIC_TEST_API_KEY || "",
             walletConnectProjectId: "",
-            keepKey: localStorage.getItem("keepkeyApiKey") || "",
+            keepKey: localStorage.getItem("keepkeyApiKey") || "1234",
           },
           integrations: {
             keepKey: {
               name: "THORSwap",
               imageUrl: "https://www.thorswap.finance/logo.png",
-              basePath: "swap",
-              url: "https://app.thorswap.finance",
+              basePath: "http://localhost:1646/spec/swagger.json",
+              url: "http://localhost:1646",
             },
           },
         },

--- a/playgrounds/vite/src/WalletPicker.tsx
+++ b/playgrounds/vite/src/WalletPicker.tsx
@@ -2,6 +2,7 @@ import {
   Chain,
   CosmosChains,
   EVMChains,
+  SKConfig,
   SubstrateChains,
   UTXOChains,
   WalletOption,
@@ -75,6 +76,7 @@ export const availableChainsByWallet = {
   [WalletOption.KEEPKEY]: [
     Chain.Arbitrum,
     Chain.Avalanche,
+    Chain.Base,
     Chain.BinanceSmartChain,
     Chain.Bitcoin,
     Chain.BitcoinCash,
@@ -189,7 +191,10 @@ export const WalletPicker = ({ skClient, setWallet, setPhrase }: Props) => {
           );
 
           await skClient.connectKeepkey?.(chains, derivationPaths);
-          localStorage.setItem("keepkeyApiKey", "1234");
+          const kkKey = SKConfig.get("apiKeys").keepKey;
+          if (kkKey) {
+            localStorage.setItem("keepkeyApiKey", kkKey);
+          }
           return true;
         }
         case WalletOption.KEEPKEY_BEX:


### PR DESCRIPTION
PR Summary
• Fixed KeepKey wallet package
– API key now managed via SKConfig
.

• Demo apps updated
– After successful KeepKey pairing, persist the final API key to localStorage using 
SKConfig
 value (non-blocking, SSR-safe).

• Added missing Base chain support wherever KeepKey/EVM chain lists are defined.

Result: platform-agnostic KeepKey package, seamless key persistence in the playgrounds, and full Base chain coverage.