### PR TITLE
feat: add XRP support for KeepKey wallet

### DIFF
--- a/packages/core/src/helpers/explorerUrls.ts
+++ b/packages/core/src/helpers/explorerUrls.ts
@@ -34,6 +34,7 @@ export function getExplorerTxUrl({ chain, txHash }: { txHash: string; chain: Cha
       () => `${baseUrl}/transaction/${txHash.toLowerCase()}`,
     )
     .with(Chain.Near, () => `${baseUrl}/txns/${txHash}`)
+    .with(Chain.Ripple, () => `${baseUrl}/transactions/${txHash}`)
     .otherwise(() => "");
 
   return explorerUrl;

--- a/packages/wallets/src/keepkey-bex/index.ts
+++ b/packages/wallets/src/keepkey-bex/index.ts
@@ -36,6 +36,7 @@ export const keepkeyBexWallet = createWallet({
     Chain.Maya,
     Chain.Optimism,
     Chain.Polygon,
+    Chain.Ripple,
     Chain.Solana,
     Chain.THORChain,
   ],

--- a/packages/wallets/src/keepkey/chains/ripple.ts
+++ b/packages/wallets/src/keepkey/chains/ripple.ts
@@ -1,0 +1,118 @@
+import type { KeepKeySdk } from "@keepkey/keepkey-sdk";
+import {
+  Chain,
+  DerivationPath,
+  type DerivationPathArray,
+  type GenericTransferParams,
+  derivationPathToString,
+} from "@swapkit/helpers";
+import { bip32ToAddressNList } from "../coins";
+
+import { getRippleToolbox } from "@swapkit/toolboxes/ripple";
+
+export const rippleWalletMethods = async ({
+  sdk,
+  derivationPath,
+}: {
+  sdk: KeepKeySdk;
+  derivationPath?: DerivationPathArray;
+}) => {
+  // Derivation path handling (default to standard XRP 44'/144'/0'/0/0)
+  const derivationPathString = derivationPath
+    ? derivationPathToString(derivationPath)
+    : `${DerivationPath[Chain.Ripple]}/0`;
+
+  // Fetch address from KeepKey
+  // @ts-ignore - keepkey-sdk typings may not yet include xrpGetAddress
+  const { address } = await (sdk as any).address.xrpGetAddress({
+    address_n: bip32ToAddressNList(derivationPathString),
+  });
+
+  // Inject minimal signer so toolbox's address helpers work
+  const signer = {
+    getAddress: () => Promise.resolve(address),
+    signTransaction: () => {
+      throw new Error("signTransaction not supported via toolbox");
+    },
+  };
+
+  const toolbox = await getRippleToolbox({ signer });
+
+  const transfer = async ({ recipient, assetValue, memo }: GenericTransferParams) => {
+    // Build XRPL Payment tx using toolbox helper
+    const tx = await toolbox.createTransaction({
+      assetValue,
+      recipient,
+      memo,
+      sender: address,
+    });
+
+    // Convert toolbox Payment tx into KeepKey StdTx wrapper (KeepKey-specific format)
+    const stdTx = {
+      type: "auth/StdTx",
+      value: {
+        fee: {
+          amount: [
+            {
+              amount: "1000",
+              denom: "drop",
+            },
+          ],
+          gas: "28000",
+        },
+        memo: memo && memo.length > 0 ? memo : "",
+        msg: [
+          {
+            type: "ripple-sdk/MsgSend",
+            value: {
+              amount: [
+                {
+                  amount: tx.Amount,
+                  denom: "drop",
+                },
+              ],
+              from_address: address,
+              to_address: recipient,
+            },
+          },
+        ],
+        signatures: null,
+      },
+    };
+
+    const unsignedTx = {
+      addressNList: bip32ToAddressNList(derivationPathString),
+      tx: stdTx,
+      flags: tx.Flags === 0 ? undefined : tx.Flags,
+      lastLedgerSequence: tx.LastLedgerSequence?.toString(),
+      sequence: (tx.Sequence ?? 0).toString(),
+      payment: {
+        amount: tx.Amount,
+        destination: tx.Destination,
+        destinationTag: (tx.DestinationTag ?? "0").toString(),
+      },
+    } as any;
+
+    // Sign with KeepKey
+    // @ts-ignore - typings missing
+    const responseSign = JSON.parse(await (sdk as any).xrp.xrpSignTransaction(unsignedTx));
+
+    // keepkey-sdk may return either { tx_blob } or StdTx with Base64 serializedTx
+    const txBlob: string | undefined =
+      (responseSign as any).tx_blob ?? (responseSign as any).value?.signatures?.[0]?.serializedTx;
+    if (!txBlob) throw new Error("KeepKey XRP sign failed");
+
+    const buffer = Buffer.from(txBlob, "base64");
+    const txBlobHex = buffer.toString("hex");
+
+    // Broadcast signed tx via toolbox
+    return toolbox.broadcastTransaction(txBlobHex);
+  };
+
+  return {
+    ...toolbox,
+    address,
+    getAddress: () => address,
+    transfer,
+  };
+};

--- a/packages/wallets/src/keepkey/coins.ts
+++ b/packages/wallets/src/keepkey/coins.ts
@@ -12,6 +12,7 @@ export enum ChainToKeepKeyName {
   DOGE = "Dogecoin",
   LTC = "Litecoin",
   DASH = "Dash",
+  XRP = "Ripple",
 }
 
 export function addressNListToBIP32(address: number[]) {

--- a/packages/wallets/src/keepkey/index.ts
+++ b/packages/wallets/src/keepkey/index.ts
@@ -33,6 +33,7 @@ export const keepkeyWallet = createWallet({
     Chain.Dash,
     Chain.Ethereum,
     Chain.Litecoin,
+    Chain.Ripple,
     Chain.Optimism,
     Chain.Polygon,
     Chain.THORChain,
@@ -115,6 +116,10 @@ async function getWalletMethods({
     case Chain.Dogecoin:
     case Chain.Litecoin: {
       return utxoWalletMethods({ sdk, chain, derivationPath });
+    }
+    case Chain.Ripple: {
+      const { rippleWalletMethods } = await import("./chains/ripple");
+      return rippleWalletMethods({ sdk, derivationPath });
     }
     default:
       throw new SwapKitError("wallet_keepkey_chain_not_supported", { chain });

--- a/playgrounds/vite/src/WalletPicker.tsx
+++ b/playgrounds/vite/src/WalletPicker.tsx
@@ -42,6 +42,7 @@ const AllChainsSupported = [
   Chain.Polkadot,
   Chain.Maya,
   Chain.Kujira,
+  Chain.Ripple,
   Chain.THORChain,
   Chain.Solana,
 ] as Chain[];
@@ -91,6 +92,7 @@ export const availableChainsByWallet = {
     Chain.Dogecoin,
     Chain.Ethereum,
     Chain.Litecoin,
+    Chain.Ripple,
     Chain.Optimism,
     Chain.Polygon,
     Chain.THORChain,
@@ -108,6 +110,7 @@ export const availableChainsByWallet = {
     Chain.Dogecoin,
     Chain.Ethereum,
     Chain.Litecoin,
+    Chain.Ripple,
     Chain.Optimism,
     Chain.Polygon,
     Chain.THORChain,


### PR DESCRIPTION
Description

This PR adds XRP (Ripple) support for KeepKey hardware wallets.
Changes

✅ Added XRP wallet methods for KeepKey (packages/wallets/src/keepkey/chains/ripple.ts)
✅ Updated KeepKey supported chains to include Ripple
✅ Added XRP coin configuration for KeepKey
✅ Added XRP explorer URL support for transaction viewing
✅ Updated playground to demonstrate XRP support in KeepKey wallets

Technical Details
Uses the existing Ripple toolbox from SwapKit
Implements KeepKey's specific transaction signing format for XRP
Follows the same pattern as other KeepKey chain implementations
No changes to core toolbox functionality - only KeepKey-specific integration