### PR TITLE
feat: implement a big chunk of swap widget UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5119,6 +5119,8 @@
 
     "@stellar/stellar-sdk/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport": ["@ledgerhq/hw-transport@6.31.12", "", { "dependencies": { "@ledgerhq/devices": "8.6.1", "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "events": "^3.3.0" } }, "sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q=="],
+
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@thaunknown/simple-websocket/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
@@ -6304,6 +6306,10 @@
     "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/codecs-strings": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw=="],
 
     "@stacks/common/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/devices": ["@ledgerhq/devices@8.6.1", "", { "dependencies": { "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "rxjs": "^7.8.1", "semver": "^7.3.5" } }, "sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ=="],
+
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/errors": ["@ledgerhq/errors@6.26.0", "", {}, "sha512-4OlisaDBafkn7KN5emue08lCGMVREX6T+nxj47C7W30EBA/leLAEDaVvUw5/gFOWrv8Q2A9Scb8aMM3uokyt0w=="],
 
     "@trezor/connect/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5127,6 +5127,8 @@
 
     "@stellar/stellar-sdk/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport": ["@ledgerhq/hw-transport@6.31.12", "", { "dependencies": { "@ledgerhq/devices": "8.6.1", "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "events": "^3.3.0" } }, "sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q=="],
+
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@thaunknown/simple-websocket/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
@@ -6312,6 +6314,10 @@
     "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/codecs-strings": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw=="],
 
     "@stacks/common/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/devices": ["@ledgerhq/devices@8.6.1", "", { "dependencies": { "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "rxjs": "^7.8.1", "semver": "^7.3.5" } }, "sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ=="],
+
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/errors": ["@ledgerhq/errors@6.26.0", "", {}, "sha512-4OlisaDBafkn7KN5emue08lCGMVREX6T+nxj47C7W30EBA/leLAEDaVvUw5/gFOWrv8Q2A9Scb8aMM3uokyt0w=="],
 
     "@trezor/connect/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -2193,7 +2193,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
+    "axios": ["axios@1.12.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -2235,7 +2235,7 @@
 
     "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.10", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-uLfgBi+7IBNay8ECBO2mVMGZAc1VgZWEChxm4lv+TobGdG82LnXMjuNGo/BSSZZL4UmkWhxEHP2f5ziLNwGWMA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-i+sRXGhz4+QW8aACZ3+r1GAKMt0wlFpeA8M5rOQd0HEYw9zhDrlx9Wc8uQ0IdXakjJRthzglEwfB/yqIjO6iDg=="],
 
     "bchaddrjs": ["bchaddrjs@0.5.2", "", { "dependencies": { "bs58check": "2.1.2", "buffer": "^6.0.3", "cashaddrjs": "0.4.4", "stream-browserify": "^3.0.0" } }, "sha512-OO7gIn3m7ea4FVx4cT8gdlWQR2+++EquhdpWQJH9BQjK63tJJ6ngB3QMZDO6DiBoXiIGUsTPHjlrHVxPGcGxLQ=="],
 
@@ -4783,15 +4783,23 @@
 
     "@keplr-wallet/types/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
 
+    "@ledgerhq/cryptoassets-evm-signatures/axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
+
     "@ledgerhq/domain-service/@ledgerhq/errors": ["@ledgerhq/errors@6.26.0", "", {}, "sha512-4OlisaDBafkn7KN5emue08lCGMVREX6T+nxj47C7W30EBA/leLAEDaVvUw5/gFOWrv8Q2A9Scb8aMM3uokyt0w=="],
+
+    "@ledgerhq/domain-service/axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
 
     "@ledgerhq/domain-service/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "@ledgerhq/domain-service/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "@ledgerhq/evm-tools/axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
+
     "@ledgerhq/hw-app-btc/bitcoinjs-lib": ["bitcoinjs-lib@5.2.0", "", { "dependencies": { "bech32": "^1.1.2", "bip174": "^2.0.1", "bip32": "^2.0.4", "bip66": "^1.1.0", "bitcoin-ops": "^1.4.0", "bs58check": "^2.0.0", "create-hash": "^1.1.0", "create-hmac": "^1.1.3", "merkle-lib": "^2.0.10", "pushdata-bitcoin": "^1.0.1", "randombytes": "^2.0.1", "tiny-secp256k1": "^1.1.1", "typeforce": "^1.11.3", "varuint-bitcoin": "^1.0.4", "wif": "^2.0.1" } }, "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ=="],
 
     "@ledgerhq/hw-app-btc/bs58check": ["bs58check@2.1.2", "", { "dependencies": { "bs58": "^4.0.0", "create-hash": "^1.1.0", "safe-buffer": "^5.1.2" } }, "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA=="],
+
+    "@ledgerhq/hw-app-eth/axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
 
     "@ledgerhq/hw-app-near/near-api-js": ["near-api-js@3.0.4", "", { "dependencies": { "@near-js/accounts": "1.0.4", "@near-js/crypto": "1.2.1", "@near-js/keystores": "0.0.9", "@near-js/keystores-browser": "0.0.9", "@near-js/keystores-node": "0.0.9", "@near-js/providers": "0.1.1", "@near-js/signers": "0.1.1", "@near-js/transactions": "1.1.2", "@near-js/types": "0.0.4", "@near-js/utils": "0.1.0", "@near-js/wallet-account": "1.1.1", "@noble/curves": "1.2.0", "ajv": "8.11.2", "ajv-formats": "2.1.1", "bn.js": "5.2.1", "borsh": "1.0.0", "depd": "2.0.0", "http-errors": "1.7.2", "near-abi": "0.1.1", "node-fetch": "2.6.7" } }, "sha512-qKWjnugoB7kSFhzZ5GXyH/eABspCQYWBmWnM4hpV5ctnQBt89LqgEu9yD1z4sa89MvUu8BuCxwb1m00BE8iofg=="],
 
@@ -5119,8 +5127,6 @@
 
     "@stellar/stellar-sdk/bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
-    "@swapkit/wallet-hardware/@ledgerhq/hw-transport": ["@ledgerhq/hw-transport@6.31.12", "", { "dependencies": { "@ledgerhq/devices": "8.6.1", "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "events": "^3.3.0" } }, "sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q=="],
-
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@thaunknown/simple-websocket/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
@@ -5216,8 +5222,6 @@
     "@xrplf/isomorphic/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "abi-wan-kanabi/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
-    "ajv-formats/ajv": ["ajv@8.11.2", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
@@ -6041,6 +6045,8 @@
 
     "tronweb/@babel/runtime": ["@babel/runtime@7.26.10", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw=="],
 
+    "tronweb/axios": ["axios@1.11.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA=="],
+
     "tronweb/ethereum-cryptography": ["ethereum-cryptography@2.2.1", "", { "dependencies": { "@noble/curves": "1.4.2", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0" } }, "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg=="],
 
     "tronweb/ethers": ["ethers@6.13.5", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ=="],
@@ -6306,10 +6312,6 @@
     "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/codecs-strings": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw=="],
 
     "@stacks/common/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/devices": ["@ledgerhq/devices@8.6.1", "", { "dependencies": { "@ledgerhq/errors": "^6.26.0", "@ledgerhq/logs": "^6.13.0", "rxjs": "^7.8.1", "semver": "^7.3.5" } }, "sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ=="],
-
-    "@swapkit/wallet-hardware/@ledgerhq/hw-transport/@ledgerhq/errors": ["@ledgerhq/errors@6.26.0", "", {}, "sha512-4OlisaDBafkn7KN5emue08lCGMVREX6T+nxj47C7W30EBA/leLAEDaVvUw5/gFOWrv8Q2A9Scb8aMM3uokyt0w=="],
 
     "@trezor/connect/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 

--- a/playgrounds/nextjs/next.config.mjs
+++ b/playgrounds/nextjs/next.config.mjs
@@ -8,7 +8,13 @@ const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
 
   images: {
-    remotePatterns: [{ hostname: "storage.googleapis.com", pathname: "/token-list-swapkit/**", protocol: "https" }],
+    remotePatterns: [
+      {
+        hostname: "storage.googleapis.com",
+        pathname: process.env.NODE_ENV === "development" ? "/token-list-swapkit-dev/**" : "/token-list-swapkit/**",
+        protocol: "https",
+      },
+    ],
   },
   reactStrictMode: true,
   typescript: { ignoreBuildErrors: true },

--- a/playgrounds/nextjs/src/app/globals.css
+++ b/playgrounds/nextjs/src/app/globals.css
@@ -24,6 +24,9 @@
     --secondary: 120 3% 13%;
     --secondary-foreground: var(--white) / 0.92;
 
+    --tertiary: var(--white) / 0.92;
+    --tertiary-foreground: 120 3% 13%;
+
     --muted: var(--secondary);
     --muted-foreground: var(--white) / 0.64;
 
@@ -33,7 +36,7 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 60 9.1% 97.8%;
 
-    --border: 12 6.5% 15.1%;
+    --border: var(--white) / 0.12;
     --input: 12 6.5% 15.1%;
     --ring: 24 5.7% 82.9%;
   }

--- a/playgrounds/nextjs/src/app/globals.css
+++ b/playgrounds/nextjs/src/app/globals.css
@@ -4,23 +4,28 @@
 
 @layer base {
   :root {
-    --background: 20 14.3% 4.1%;
-    --foreground: 60 9.1% 97.8%;
+    --navbar-height: 4rem;
 
-    --card: 20 14.3% 4.1%;
-    --card-foreground: 60 9.1% 97.8%;
+    --white: 0 0% 100%;
+    --black: 0 0% 0%;
+
+    --background: var(--primary);
+    --foreground: var(--primary-foreground);
+
+    --card: var(--secondary);
+    --card-foreground: var(--secondary-foreground);
 
     --popover: 20 14.3% 4.1%;
     --popover-foreground: 60 9.1% 97.8%;
 
-    --primary: 60 9.1% 97.8%;
-    --primary-foreground: 24 9.8% 10%;
+    --primary: 140 6% 8%;
+    --primary-foreground: var(--white) / 92%;
 
-    --secondary: 12 6.5% 15.1%;
-    --secondary-foreground: 60 9.1% 97.8%;
+    --secondary: 120 3% 13%;
+    --secondary-foreground: var(--white) / 0.92;
 
-    --muted: 12 6.5% 15.1%;
-    --muted-foreground: 24 5.4% 63.9%;
+    --muted: var(--secondary);
+    --muted-foreground: var(--white) / 0.64;
 
     --accent: 12 6.5% 15.1%;
     --accent-foreground: 60 9.1% 97.8%;
@@ -36,7 +41,7 @@
 
 @layer base {
   * {
-    @apply border-border;
+    @apply border-border antialiased;
   }
   body {
     @apply bg-background text-foreground;

--- a/playgrounds/nextjs/src/app/layout.tsx
+++ b/playgrounds/nextjs/src/app/layout.tsx
@@ -13,9 +13,12 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     <html className="dark" lang="en" style={{ colorScheme: "dark" }}>
       <body className={inter.className}>
         <AppProviders>
-          <div className="mx-auto max-w-[800px]">
+          <div className="flex min-h-screen w-full flex-col items-center">
             <NavigationBar />
-            <div className="flex items-center justify-center">{children}</div>
+
+            <div className="mx-auto w-full max-w-screen-lg pt-[calc(var(--navbar-height)+4rem)] [&>*]:mx-auto [&>*]:max-w-xl">
+              {children}
+            </div>
           </div>
         </AppProviders>
       </body>

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -21,32 +21,13 @@ import {
 import { useSwapKit } from "~/lib/swapKit";
 
 export default function SwapPage() {
-  const { balances, swapKit, isWalletConnected } = useSwapKit();
+  const { swapKit, isWalletConnected } = useSwapKit();
   const [inputAsset, setInputAsset] = useState<string>();
   const [outputAsset, setOutputAsset] = useState<string>();
   const [amount, setAmount] = useState("");
   const [isSwapping, setIsSwapping] = useState(false);
-  const [estimatedOutput, setEstimatedOutput] = useState<string>();
+  const [_estimatedOutput, setEstimatedOutput] = useState<string>();
   const [routes, setRoutes] = useState<QuoteResponseRoute[]>([]);
-
-  const { chains, balanceGroupedByChain } = useMemo(() => {
-    const balanceGroupedByChain = (Array.isArray(balances) ? balances : []).reduce(
-      (acc: Record<Chain, AssetValue[]>, assetValue: AssetValue) => {
-        if (!acc[assetValue.chain]) {
-          acc[assetValue.chain] = [];
-        }
-
-        if (assetValue.isGasAsset || assetValue.getValue("number") > 0) {
-          acc[assetValue.chain].push(assetValue);
-        }
-
-        return acc;
-      },
-      {} as Record<Chain, AssetValue[]>,
-    );
-
-    return { balanceGroupedByChain, chains: Object.keys(balanceGroupedByChain) as Chain[] };
-  }, [balances]);
 
   const handleSwap = async (route: QuoteResponseRoute) => {
     if (!swapKit) return;
@@ -141,54 +122,14 @@ export default function SwapPage() {
         <CardContent className="grid gap-6">
           <div className="space-y-4">
             <div className="grid gap-4">
-              <div className="-my-2">
-                <span className="text-muted-foreground text-xs">Pay</span>
-
-                <div className="flex justify-between">
-                  <Select onValueChange={setInputAsset} value={inputAsset}>
-                    <SelectTrigger className="w-auto min-w-0">
-                      <SelectValue placeholder="Select input asset" />
-                    </SelectTrigger>
-
-                    <SelectContent>
-                      {chains.map((chain) => {
-                        if (!balanceGroupedByChain[chain]?.length) return null;
-
-                        return (
-                          <SelectGroup key={chain}>
-                            <SelectLabel>{chain}</SelectLabel>
-
-                            {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
-                              <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                                <div className="flex w-full items-center justify-between">
-                                  <span>{assetValue.symbol}</span>
-
-                                  <span className="text-muted-foreground">
-                                    {assetValue.getValue("number").toFixed(6)}
-                                  </span>
-                                </div>
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
-
-                  <div className="flex flex-col items-end gap-2">
-                    <Input
-                      className="-mr-4 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
-                      disabled={!inputAsset || isSwapping}
-                      onChange={(e) => setAmount(e.target.value)}
-                      placeholder="0.00"
-                      type="text"
-                      value={amount}
-                    />
-
-                    <span className="text-muted-foreground text-sm">$0.00</span>
-                  </div>
-                </div>
-              </div>
+              <SwapInputWithChainSelector
+                amount={amount}
+                isSwapping={isSwapping}
+                label="Pay"
+                selectedAsset={inputAsset}
+                setAmount={setAmount}
+                setSelectedAsset={setInputAsset}
+              />
 
               <div className="-my-4 flex items-center space-x-4">
                 <span className="h-px w-full bg-border" />
@@ -208,35 +149,14 @@ export default function SwapPage() {
                 <span className="h-px w-full bg-border" />
               </div>
 
-              <div className="grid gap-2">
-                <Select onValueChange={setOutputAsset} value={outputAsset}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select output asset" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {chains.map((chain) =>
-                      balanceGroupedByChain[chain]?.length ? (
-                        <SelectGroup key={chain}>
-                          <SelectLabel>{chain}</SelectLabel>
-                          {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
-                            <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                              <div className="flex w-full items-center justify-between">
-                                <span>{assetValue.symbol}</span>
-                                <span className="text-muted-foreground">
-                                  {assetValue.getValue("number").toFixed(6)}
-                                </span>
-                              </div>
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      ) : null,
-                    )}
-                  </SelectContent>
-                </Select>
-                {estimatedOutput && (
-                  <div className="text-right text-muted-foreground text-sm">Expected output: {estimatedOutput}</div>
-                )}
-              </div>
+              <SwapInputWithChainSelector
+                amount={amount}
+                isSwapping={isSwapping}
+                label="Receive"
+                selectedAsset={outputAsset}
+                setAmount={setOutputAsset}
+                setSelectedAsset={setOutputAsset}
+              />
             </div>
           </div>
         </CardContent>
@@ -277,6 +197,99 @@ export default function SwapPage() {
           "Connect wallet"
         )}
       </Button>
+    </div>
+  );
+}
+
+function SwapInputWithChainSelector({
+  label,
+
+  selectedAsset,
+  setSelectedAsset,
+
+  amount,
+  setAmount,
+
+  isSwapping,
+}: {
+  label: string;
+
+  // TODO: move to react-hook-form
+  selectedAsset: string | undefined;
+  setSelectedAsset: (asset: string | undefined) => void;
+  amount: string | undefined;
+  setAmount: (amount: string) => void;
+  isSwapping: boolean;
+}) {
+  const { balances } = useSwapKit();
+
+  const { chains, balanceGroupedByChain } = useMemo(() => {
+    const balanceGroupedByChain = (Array.isArray(balances) ? balances : []).reduce(
+      (acc: Record<Chain, AssetValue[]>, assetValue: AssetValue) => {
+        if (!acc[assetValue.chain]) {
+          acc[assetValue.chain] = [];
+        }
+
+        if (assetValue.isGasAsset || assetValue.getValue("number") > 0) {
+          acc[assetValue.chain].push(assetValue);
+        }
+
+        return acc;
+      },
+      {} as Record<Chain, AssetValue[]>,
+    );
+
+    const chains = Object.keys(balanceGroupedByChain) as Chain[];
+
+    return { balanceGroupedByChain, chains };
+  }, [balances]);
+
+  return (
+    <div className="-my-2">
+      <span className="text-muted-foreground text-xs">{label}</span>
+
+      <div className="flex justify-between">
+        <Select onValueChange={setSelectedAsset} value={selectedAsset}>
+          <SelectTrigger className="w-auto min-w-0">
+            <SelectValue placeholder="Select input asset" />
+          </SelectTrigger>
+
+          <SelectContent>
+            {chains.map((chain) => {
+              if (!balanceGroupedByChain[chain]?.length) return null;
+
+              return (
+                <SelectGroup key={chain}>
+                  <SelectLabel>{chain}</SelectLabel>
+
+                  {balanceGroupedByChain[chain]?.map((assetValue: AssetValue) => (
+                    <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
+                      <div className="flex w-full items-center justify-between">
+                        <span>{assetValue.symbol}</span>
+
+                        <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              );
+            })}
+          </SelectContent>
+        </Select>
+
+        <div className="flex flex-col items-end gap-2">
+          <Input
+            className="-mr-4 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
+            disabled={!selectedAsset || isSwapping}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0.00"
+            type="text"
+            value={amount}
+          />
+
+          <span className="text-muted-foreground text-sm">$0.00</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -4,27 +4,20 @@ import { AssetValue, type Chain } from "@swapkit/helpers";
 import type { QuoteResponseRoute } from "@swapkit/helpers/api";
 import { ProviderName, SwapKitApi } from "@swapkit/sdk";
 import { ArrowDownUp, Loader2 } from "lucide-react";
+import Image from "next/image";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
 import { useSwapKit } from "~/lib/swapKit";
 
 export default function SwapPage() {
   const { swapKit, isWalletConnected } = useSwapKit();
-  const [inputAsset, setInputAsset] = useState<string>();
-  const [outputAsset, setOutputAsset] = useState<string>();
-  const [amount, setAmount] = useState("");
+  const [inputAsset, setInputAsset] = useState<string>("NEAR.USDT-usdt.tether-token.near");
+  const [outputAsset, setOutputAsset] = useState<string>("THOR.RUNE");
+  const [amount, setAmount] = useState("4.20");
   const [isSwapping, setIsSwapping] = useState(false);
   const [estimatedOutput, setEstimatedOutput] = useState<string>();
   const [routes, setRoutes] = useState<QuoteResponseRoute[]>([]);
@@ -175,7 +168,7 @@ export default function SwapPage() {
             toast.error(`Failed to prepare swap: ${error instanceof Error ? error.message : "Unknown error"}`);
           }
         }}
-        size="lg"
+        size="xl"
         variant="primary">
         {isSwapping ? (
           <>
@@ -227,7 +220,7 @@ function SwapInputWithChainSelector({
       <div className="flex justify-between">
         <SwapAssetSelect selectedAsset={selectedAsset} setSelectedAsset={setSelectedAsset} />
 
-        <div className="flex flex-col items-end gap-2">
+        <div className="flex flex-col items-end">
           <Input
             className="-mr-4 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
             disabled={!selectedAsset || isSwapping || !setAmount}
@@ -251,35 +244,94 @@ function SwapAssetSelect({
   selectedAsset: string | undefined;
   setSelectedAsset: (asset: string | undefined) => void;
 }) {
+  const [open, setOpen] = useState(false);
   const { chains, balanceGroupedByChain } = useSwapKit();
 
+  useEffect(() => {
+    if (!selectedAsset) return;
+
+    setOpen(false);
+  }, [selectedAsset]);
+
   return (
-    <Select onValueChange={setSelectedAsset} value={selectedAsset}>
-      <SelectTrigger className="mt-1 w-auto min-w-0">
-        <SelectValue placeholder="Select input asset" />
-      </SelectTrigger>
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger className="-ml-2 mt-1 w-auto min-w-48 max-w-1/2 rounded-lg px-2 transition-colors duration-100 hover:bg-white/[0.08]">
+        <SwapAssetItem asset={selectedAsset} />
+      </DialogTrigger>
 
-      <SelectContent>
-        {chains.map((chain) => {
-          if (!balanceGroupedByChain[chain]?.length) return null;
+      <DialogContent>
+        <DialogHeader>Select Token</DialogHeader>
 
-          return (
-            <SelectGroup key={chain}>
-              <SelectLabel>{chain}</SelectLabel>
+        <Input placeholder="Search" />
 
-              {balanceGroupedByChain[chain]?.map((assetValue: AssetValue) => (
-                <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                  <div className="flex w-full items-center justify-between">
-                    <span>{assetValue.symbol}</span>
+        <span className="text-muted-foreground text-sm">
+          Network: <span className="text-foreground">All</span>
+        </span>
 
-                    <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          );
-        })}
-      </SelectContent>
-    </Select>
+        <div className="grid gap-4">
+          {chains.map((chain) => {
+            if (!balanceGroupedByChain[chain]?.length) return null;
+
+            return (
+              <div className="flex flex-col gap-2" key={`select-asset-chain-${chain}`}>
+                {balanceGroupedByChain[chain]?.map((assetValue) => (
+                  <Button
+                    className="-mx-2 w-auto flex-1 justify-between rounded-lg px-2 py-1"
+                    key={`swap-asset-item-${assetValue.toString()}`}
+                    onClick={() => setSelectedAsset?.(assetValue.toString())}
+                    variant="ghost">
+                    <SwapAssetItem asset={assetValue.toString()} key={`swap-asset-item-${assetValue.toString()}`} />
+
+                    <div className="flex flex-col items-end">
+                      <span className="font-medium text-base text-foreground">Label</span>
+
+                      <span className="-mt-0.5 text-muted-foreground text-sm">Label</span>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SwapAssetItem({ asset }: { asset: string | undefined }) {
+  if (!asset) return;
+
+  const assetValue = AssetValue.from({ asset });
+
+  const iconUrl = assetValue?.getIconUrl();
+
+  if (!iconUrl) return;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative">
+        <Image
+          alt={assetValue?.symbol}
+          className="size-10 overflow-hidden rounded-full"
+          height={40}
+          src={iconUrl}
+          width={40}
+        />
+
+        <Image
+          alt={assetValue?.chainId}
+          className="-bottom-0.5 absolute right-0 size-4 rounded-full border-2 border-secondary bg-secondary"
+          height={16}
+          src={iconUrl}
+          width={16}
+        />
+      </div>
+
+      <div className="flex flex-col items-start">
+        <span className="font-medium text-base text-foreground">{assetValue?.ticker}</span>
+
+        <span className="-mt-0.5 text-muted-foreground text-sm">{assetValue?.chain}</span>
+      </div>
+    </div>
   );
 }

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -141,41 +141,56 @@ export default function SwapPage() {
         <CardContent className="grid gap-6">
           <div className="space-y-4">
             <div className="grid gap-4">
-              <div className="grid gap-2">
-                <Select onValueChange={setInputAsset} value={inputAsset}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select input asset" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {chains.map((chain) =>
-                      balanceGroupedByChain[chain]?.length ? (
-                        <SelectGroup key={chain}>
-                          <SelectLabel>{chain}</SelectLabel>
-                          {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
-                            <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                              <div className="flex w-full items-center justify-between">
-                                <span>{assetValue.symbol}</span>
-                                <span className="text-muted-foreground">
-                                  {assetValue.getValue("number").toFixed(6)}
-                                </span>
-                              </div>
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      ) : null,
-                    )}
-                  </SelectContent>
-                </Select>
-                <Input
-                  disabled={!inputAsset || isSwapping}
-                  onChange={(e) => setAmount(e.target.value)}
-                  placeholder="Amount"
-                  type="number"
-                  value={amount}
-                />
+              <div className="-my-2">
+                <span className="text-muted-foreground text-xs">Pay</span>
+
+                <div className="flex justify-between">
+                  <Select onValueChange={setInputAsset} value={inputAsset}>
+                    <SelectTrigger className="w-auto min-w-0">
+                      <SelectValue placeholder="Select input asset" />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      {chains.map((chain) => {
+                        if (!balanceGroupedByChain[chain]?.length) return null;
+
+                        return (
+                          <SelectGroup key={chain}>
+                            <SelectLabel>{chain}</SelectLabel>
+
+                            {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
+                              <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
+                                <div className="flex w-full items-center justify-between">
+                                  <span>{assetValue.symbol}</span>
+
+                                  <span className="text-muted-foreground">
+                                    {assetValue.getValue("number").toFixed(6)}
+                                  </span>
+                                </div>
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+
+                  <div className="flex flex-col items-end gap-2">
+                    <Input
+                      className="-mr-4 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
+                      disabled={!inputAsset || isSwapping}
+                      onChange={(e) => setAmount(e.target.value)}
+                      placeholder="0.00"
+                      type="text"
+                      value={amount}
+                    />
+
+                    <span className="text-muted-foreground text-sm">$0.00</span>
+                  </div>
+                </div>
               </div>
 
-              <div className="flex items-center space-x-4">
+              <div className="-my-4 flex items-center space-x-4">
                 <span className="h-px w-full bg-border" />
 
                 <Button

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -4,7 +4,7 @@ import { AssetValue, type Chain } from "@swapkit/helpers";
 import type { QuoteResponseRoute } from "@swapkit/helpers/api";
 import { ProviderName, SwapKitApi } from "@swapkit/sdk";
 import { ArrowDownUp, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
@@ -26,7 +26,7 @@ export default function SwapPage() {
   const [outputAsset, setOutputAsset] = useState<string>();
   const [amount, setAmount] = useState("");
   const [isSwapping, setIsSwapping] = useState(false);
-  const [_estimatedOutput, setEstimatedOutput] = useState<string>();
+  const [estimatedOutput, setEstimatedOutput] = useState<string>();
   const [routes, setRoutes] = useState<QuoteResponseRoute[]>([]);
 
   const handleSwap = async (route: QuoteResponseRoute) => {
@@ -150,11 +150,10 @@ export default function SwapPage() {
               </div>
 
               <SwapInputWithChainSelector
-                amount={amount}
+                amount={estimatedOutput}
                 isSwapping={isSwapping}
                 label="Receive"
                 selectedAsset={outputAsset}
-                setAmount={setOutputAsset}
                 setSelectedAsset={setOutputAsset}
               />
             </div>
@@ -218,70 +217,21 @@ function SwapInputWithChainSelector({
   selectedAsset: string | undefined;
   setSelectedAsset: (asset: string | undefined) => void;
   amount: string | undefined;
-  setAmount: (amount: string) => void;
+  setAmount?: (amount: string) => void;
   isSwapping: boolean;
 }) {
-  const { balances } = useSwapKit();
-
-  const { chains, balanceGroupedByChain } = useMemo(() => {
-    const balanceGroupedByChain = (Array.isArray(balances) ? balances : []).reduce(
-      (acc: Record<Chain, AssetValue[]>, assetValue: AssetValue) => {
-        if (!acc[assetValue.chain]) {
-          acc[assetValue.chain] = [];
-        }
-
-        if (assetValue.isGasAsset || assetValue.getValue("number") > 0) {
-          acc[assetValue.chain].push(assetValue);
-        }
-
-        return acc;
-      },
-      {} as Record<Chain, AssetValue[]>,
-    );
-
-    const chains = Object.keys(balanceGroupedByChain) as Chain[];
-
-    return { balanceGroupedByChain, chains };
-  }, [balances]);
-
   return (
     <div className="-my-2">
       <span className="text-muted-foreground text-xs">{label}</span>
 
       <div className="flex justify-between">
-        <Select onValueChange={setSelectedAsset} value={selectedAsset}>
-          <SelectTrigger className="w-auto min-w-0">
-            <SelectValue placeholder="Select input asset" />
-          </SelectTrigger>
-
-          <SelectContent>
-            {chains.map((chain) => {
-              if (!balanceGroupedByChain[chain]?.length) return null;
-
-              return (
-                <SelectGroup key={chain}>
-                  <SelectLabel>{chain}</SelectLabel>
-
-                  {balanceGroupedByChain[chain]?.map((assetValue: AssetValue) => (
-                    <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                      <div className="flex w-full items-center justify-between">
-                        <span>{assetValue.symbol}</span>
-
-                        <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              );
-            })}
-          </SelectContent>
-        </Select>
+        <SwapAssetSelect selectedAsset={selectedAsset} setSelectedAsset={setSelectedAsset} />
 
         <div className="flex flex-col items-end gap-2">
           <Input
             className="-mr-4 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
-            disabled={!selectedAsset || isSwapping}
-            onChange={(e) => setAmount(e.target.value)}
+            disabled={!selectedAsset || isSwapping || !setAmount}
+            onChange={(e) => setAmount?.(e.target.value)}
             placeholder="0.00"
             type="text"
             value={amount}
@@ -291,5 +241,45 @@ function SwapInputWithChainSelector({
         </div>
       </div>
     </div>
+  );
+}
+
+function SwapAssetSelect({
+  selectedAsset,
+  setSelectedAsset,
+}: {
+  selectedAsset: string | undefined;
+  setSelectedAsset: (asset: string | undefined) => void;
+}) {
+  const { chains, balanceGroupedByChain } = useSwapKit();
+
+  return (
+    <Select onValueChange={setSelectedAsset} value={selectedAsset}>
+      <SelectTrigger className="mt-1 w-auto min-w-0">
+        <SelectValue placeholder="Select input asset" />
+      </SelectTrigger>
+
+      <SelectContent>
+        {chains.map((chain) => {
+          if (!balanceGroupedByChain[chain]?.length) return null;
+
+          return (
+            <SelectGroup key={chain}>
+              <SelectLabel>{chain}</SelectLabel>
+
+              {balanceGroupedByChain[chain]?.map((assetValue: AssetValue) => (
+                <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
+                  <div className="flex w-full items-center justify-between">
+                    <span>{assetValue.symbol}</span>
+
+                    <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          );
+        })}
+      </SelectContent>
+    </Select>
   );
 }

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -7,7 +7,7 @@ import { ArrowDownUp, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "~/components/ui/card";
+import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import {
   Select,
@@ -134,136 +134,135 @@ export default function SwapPage() {
   }, [updateEstimatedOutput]);
 
   return (
-    <Card className="w-[600px]">
-      <CardHeader>
-        <CardTitle className="flex items-center justify-between">
-          <span>Swap</span>
-          {!isWalletConnected && (
-            <span className="font-normal text-muted-foreground text-sm">Connect wallet to start swapping</span>
-          )}
-        </CardTitle>
-      </CardHeader>
+    <div className="flex flex-col gap-4">
+      <h1 className="font-medium text-2xl">Swap</h1>
 
-      <CardContent className="grid gap-6">
-        <div className="space-y-4">
-          <div className="grid gap-4">
-            <div className="grid gap-2">
-              <Select onValueChange={setInputAsset} value={inputAsset}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select input asset" />
-                </SelectTrigger>
-                <SelectContent>
-                  {chains.map((chain) =>
-                    balanceGroupedByChain[chain]?.length ? (
-                      <SelectGroup key={chain}>
-                        <SelectLabel>{chain}</SelectLabel>
-                        {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
-                          <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                            <div className="flex w-full items-center justify-between">
-                              <span>{assetValue.symbol}</span>
-                              <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    ) : null,
-                  )}
-                </SelectContent>
-              </Select>
-              <Input
-                disabled={!inputAsset || isSwapping}
-                onChange={(e) => setAmount(e.target.value)}
-                placeholder="Amount"
-                type="number"
-                value={amount}
-              />
-            </div>
-
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <span className="w-full border-t" />
+      <Card>
+        <CardContent className="grid gap-6">
+          <div className="space-y-4">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Select onValueChange={setInputAsset} value={inputAsset}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select input asset" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {chains.map((chain) =>
+                      balanceGroupedByChain[chain]?.length ? (
+                        <SelectGroup key={chain}>
+                          <SelectLabel>{chain}</SelectLabel>
+                          {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
+                            <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
+                              <div className="flex w-full items-center justify-between">
+                                <span>{assetValue.symbol}</span>
+                                <span className="text-muted-foreground">
+                                  {assetValue.getValue("number").toFixed(6)}
+                                </span>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      ) : null,
+                    )}
+                  </SelectContent>
+                </Select>
+                <Input
+                  disabled={!inputAsset || isSwapping}
+                  onChange={(e) => setAmount(e.target.value)}
+                  placeholder="Amount"
+                  type="number"
+                  value={amount}
+                />
               </div>
-              <div className="relative flex justify-center">
-                <Button
-                  className="h-8 w-8 bg-background"
-                  onClick={() => {
-                    const temp = inputAsset;
-                    setInputAsset(outputAsset);
-                    setOutputAsset(temp);
-                  }}
-                  size="icon"
-                  variant="outline">
-                  <ArrowDownUp className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
 
-            <div className="grid gap-2">
-              <Select onValueChange={setOutputAsset} value={outputAsset}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select output asset" />
-                </SelectTrigger>
-                <SelectContent>
-                  {chains.map((chain) =>
-                    balanceGroupedByChain[chain]?.length ? (
-                      <SelectGroup key={chain}>
-                        <SelectLabel>{chain}</SelectLabel>
-                        {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
-                          <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
-                            <div className="flex w-full items-center justify-between">
-                              <span>{assetValue.symbol}</span>
-                              <span className="text-muted-foreground">{assetValue.getValue("number").toFixed(6)}</span>
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    ) : null,
-                  )}
-                </SelectContent>
-              </Select>
-              {estimatedOutput && (
-                <div className="text-right text-muted-foreground text-sm">Expected output: {estimatedOutput}</div>
-              )}
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center">
+                  <Button
+                    className="h-8 w-8 bg-background"
+                    onClick={() => {
+                      const temp = inputAsset;
+                      setInputAsset(outputAsset);
+                      setOutputAsset(temp);
+                    }}
+                    size="icon"
+                    variant="outline">
+                    <ArrowDownUp className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <Select onValueChange={setOutputAsset} value={outputAsset}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select output asset" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {chains.map((chain) =>
+                      balanceGroupedByChain[chain]?.length ? (
+                        <SelectGroup key={chain}>
+                          <SelectLabel>{chain}</SelectLabel>
+                          {balanceGroupedByChain[chain].map((assetValue: AssetValue) => (
+                            <SelectItem key={assetValue.toString()} value={assetValue.toString()}>
+                              <div className="flex w-full items-center justify-between">
+                                <span>{assetValue.symbol}</span>
+                                <span className="text-muted-foreground">
+                                  {assetValue.getValue("number").toFixed(6)}
+                                </span>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      ) : null,
+                    )}
+                  </SelectContent>
+                </Select>
+                {estimatedOutput && (
+                  <div className="text-right text-muted-foreground text-sm">Expected output: {estimatedOutput}</div>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </CardContent>
+        </CardContent>
+      </Card>
 
-      <CardFooter>
-        <Button
-          className="w-full"
-          disabled={!(inputAsset && outputAsset && amount) || isSwapping || !isWalletConnected}
-          onClick={async () => {
-            if (!(routes.length && inputAsset)) return;
-            try {
-              const assetValue = await AssetValue.from({ amount, asset: inputAsset, asyncTokenLookup: true });
-              const amountValue = assetValue.set(amount);
-              await swap(routes[0], amountValue);
-            } catch (error) {
-              console.error("Failed to prepare swap:", error);
-              toast.error(`Failed to prepare swap: ${error instanceof Error ? error.message : "Unknown error"}`);
-            }
-          }}>
-          {isSwapping ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Swapping...
-            </>
-          ) : isWalletConnected ? (
-            inputAsset && outputAsset ? (
-              amount ? (
-                "Swap"
-              ) : (
-                "Enter Amount"
-              )
+      <Button
+        className="w-full"
+        disabled={!(inputAsset && outputAsset && amount) || isSwapping || !isWalletConnected}
+        onClick={async () => {
+          if (!(routes.length && inputAsset)) return;
+          try {
+            const assetValue = await AssetValue.from({ amount, asset: inputAsset, asyncTokenLookup: true });
+            const amountValue = assetValue.set(amount);
+            await swap(routes[0], amountValue);
+          } catch (error) {
+            console.error("Failed to prepare swap:", error);
+            toast.error(`Failed to prepare swap: ${error instanceof Error ? error.message : "Unknown error"}`);
+          }
+        }}
+        size="lg"
+        variant="primary">
+        {isSwapping ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Swapping...
+          </>
+        ) : isWalletConnected ? (
+          inputAsset && outputAsset ? (
+            amount ? (
+              "Swap"
             ) : (
-              "Select Assets"
+              "Enter Amount"
             )
           ) : (
-            "Connect Wallet to Swap"
-          )}
-        </Button>
-      </CardFooter>
-    </Card>
+            "Select Assets"
+          )
+        ) : (
+          "Connect wallet"
+        )}
+      </Button>
+    </div>
   );
 }

--- a/playgrounds/nextjs/src/app/page.tsx
+++ b/playgrounds/nextjs/src/app/page.tsx
@@ -175,23 +175,22 @@ export default function SwapPage() {
                 />
               </div>
 
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center">
-                  <Button
-                    className="h-8 w-8 bg-background"
-                    onClick={() => {
-                      const temp = inputAsset;
-                      setInputAsset(outputAsset);
-                      setOutputAsset(temp);
-                    }}
-                    size="icon"
-                    variant="outline">
-                    <ArrowDownUp className="h-4 w-4" />
-                  </Button>
-                </div>
+              <div className="flex items-center space-x-4">
+                <span className="h-px w-full bg-border" />
+
+                <Button
+                  className="size-10 shrink-0 rounded-full"
+                  onClick={() => {
+                    const temp = inputAsset;
+                    setInputAsset(outputAsset);
+                    setOutputAsset(temp);
+                  }}
+                  size="unstyled"
+                  variant="tertiary">
+                  <ArrowDownUp className="size-6" />
+                </Button>
+
+                <span className="h-px w-full bg-border" />
               </div>
 
               <div className="grid gap-2">

--- a/playgrounds/nextjs/src/components/WalletButton.tsx
+++ b/playgrounds/nextjs/src/components/WalletButton.tsx
@@ -14,9 +14,13 @@ export function WalletButton() {
   return (
     <>
       {isWalletConnected ? (
-        <Button onClick={() => setDrawerOpen(true)}>My Wallet</Button>
+        <Button onClick={() => setDrawerOpen(true)} variant="primary">
+          My Wallet
+        </Button>
       ) : (
-        <Button onClick={() => setConnectOpen(true)}>Connect Wallet</Button>
+        <Button onClick={() => setConnectOpen(true)} variant="primary">
+          Connect Wallet
+        </Button>
       )}
 
       <WalletConnectDialog onOpenChange={setConnectOpen} open={connectOpen} />

--- a/playgrounds/nextjs/src/components/containers/NavigationBar.tsx
+++ b/playgrounds/nextjs/src/components/containers/NavigationBar.tsx
@@ -2,9 +2,10 @@ import { WalletButton } from "~/components/WalletButton";
 
 export function NavigationBar() {
   return (
-    <nav className="border-b">
-      <div className="flex h-16 items-center px-4">
+    <nav className="fixed top-0 right-0 left-0 flex h-[--navbar-height] items-center border-b bg-background px-2 lg:px-4">
+      <div className="mx-auto flex w-full max-w-screen-lg items-center">
         <div className="font-semibold text-lg">SwapKit Playground</div>
+
         <div className="ml-auto flex items-center space-x-4">
           <WalletButton />
         </div>

--- a/playgrounds/nextjs/src/components/ui/button.tsx
+++ b/playgrounds/nextjs/src/components/ui/button.tsx
@@ -9,13 +9,20 @@ const buttonVariants = cva(
   {
     defaultVariants: { size: "default", variant: "default" },
     variants: {
-      size: { default: "h-10 px-4 py-2", icon: "h-10 w-10", lg: "h-11 rounded-md px-8", sm: "h-9 rounded-md px-3" },
+      // biome-ignore assist/source/useSortedKeys: sort by size, not alphabetically
+      size: {
+        sm: "h-9 rounded-md px-3",
+        default: "h-10 px-4 py-2",
+        lg: "h-12 font-medium text-base rounded-xl px-8",
+        icon: "size-10",
+      },
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        primary: "bg-primary-foreground text-primary hover:bg-white/80",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
       },
     },

--- a/playgrounds/nextjs/src/components/ui/button.tsx
+++ b/playgrounds/nextjs/src/components/ui/button.tsx
@@ -15,15 +15,20 @@ const buttonVariants = cva(
         default: "h-10 px-4 py-2",
         lg: "h-12 font-medium text-base rounded-xl px-8",
         icon: "size-10",
+        unstyled: "p-0 m-0 h-auto w-auto",
       },
+      // biome-ignore assist/source/useSortedKeys: sort by role, not alphabetically
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        primary: "bg-primary-foreground text-primary hover:bg-white/80",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+
+        primary: "bg-primary-foreground text-primary hover:opacity-80 transition-opacity",
+        secondary: "bg-secondary text-secondary-foreground hover:opacity-80 transition-opacity",
+        tertiary: "bg-tertiary text-tertiary-foreground hover:opacity-80 transition-opacity",
+
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
       },
     },
   },

--- a/playgrounds/nextjs/src/components/ui/button.tsx
+++ b/playgrounds/nextjs/src/components/ui/button.tsx
@@ -13,14 +13,15 @@ const buttonVariants = cva(
       size: {
         sm: "h-9 rounded-md px-3",
         default: "h-10 px-4 py-2",
-        lg: "h-12 font-medium text-base rounded-xl px-8",
+        lg: "h-12 font-medium text-base rounded-lg px-4",
+        xl: "h-11 font-medium text-base rounded-xl px-8",
         icon: "size-10",
         unstyled: "p-0 m-0 h-auto w-auto",
       },
       // biome-ignore assist/source/useSortedKeys: sort by role, not alphabetically
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-white/[0.08] bg-transparent hover:text-foreground text-muted-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
 

--- a/playgrounds/nextjs/src/components/ui/card.tsx
+++ b/playgrounds/nextjs/src/components/ui/card.tsx
@@ -8,9 +8,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div className={cn("flex flex-col space-y-1.5 p-6", className)} ref={ref} {...props} />
-  ),
+  ({ className, ...props }, ref) => <div className={cn("flex flex-col space-y-1.5", className)} ref={ref} {...props} />,
 );
 CardHeader.displayName = "CardHeader";
 
@@ -29,14 +27,12 @@ const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttribu
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div className={cn("p-6", className)} ref={ref} {...props} />,
+  ({ className, ...props }, ref) => <div className={cn("p-4", className)} ref={ref} {...props} />,
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div className={cn("flex items-center p-6 pt-0", className)} ref={ref} {...props} />
-  ),
+  ({ className, ...props }, ref) => <div className={cn("flex items-center px-4", className)} ref={ref} {...props} />,
 );
 CardFooter.displayName = "CardFooter";
 

--- a/playgrounds/nextjs/src/components/ui/card.tsx
+++ b/playgrounds/nextjs/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "~/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} ref={ref} {...props} />
+  <div className={cn("rounded-xl bg-card text-card-foreground shadow-sm", className)} ref={ref} {...props} />
 ));
 Card.displayName = "Card";
 
@@ -29,7 +29,7 @@ const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttribu
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div className={cn("p-6 pt-0", className)} ref={ref} {...props} />,
+  ({ className, ...props }, ref) => <div className={cn("p-6", className)} ref={ref} {...props} />,
 );
 CardContent.displayName = "CardContent";
 

--- a/playgrounds/nextjs/src/lib/swapKit.ts
+++ b/playgrounds/nextjs/src/lib/swapKit.ts
@@ -4,7 +4,7 @@ import type { AssetValue, Chain, EVMChain } from "@swapkit/helpers";
 import { NetworkDerivationPath, WalletOption } from "@swapkit/helpers";
 import type { createSwapKit } from "@swapkit/sdk";
 import { atom, useAtom } from "jotai";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 type KeystoreFile = { keystore: import("@swapkit/wallets/keystore").Keystore; file: File; chains: Chain[] } | null;
 
@@ -31,6 +31,7 @@ export const useSwapKit = () => {
             swapKit: process.env.NEXT_PUBLIC_TEST_API_KEY || "",
             walletConnectProjectId: "",
           },
+          envs: { isDev: true },
           integrations: {
             keepKey: {
               basePath: "http://localhost:1646/spec/swagger.json",
@@ -215,22 +216,51 @@ export const useSwapKit = () => {
     [keystoreFile, swapKit, setWalletState, setBalances, setIsKeystoreOpen, setKeystoreFile, setIsKeystoreDecrypting],
   );
 
+  const { chains, balanceGroupedByChain } = useMemo(() => {
+    const balanceGroupedByChain = (Array.isArray(balances) ? balances : []).reduce(
+      (acc: Record<Chain, AssetValue[]>, assetValue: AssetValue) => {
+        if (!acc[assetValue.chain]) {
+          acc[assetValue.chain] = [];
+        }
+
+        if (assetValue.isGasAsset || assetValue.getValue("number") > 0) {
+          acc[assetValue.chain].push(assetValue);
+        }
+
+        return acc;
+      },
+      {} as Record<Chain, AssetValue[]>,
+    );
+
+    const chains = Object.keys(balanceGroupedByChain) as Chain[];
+
+    return { balanceGroupedByChain, chains };
+  }, [balances]);
+
+  // biome-ignore assist/source/useSortedKeys: sort by variable type/use case, not alphabetically
   return {
+    swapKit,
+
+    walletType,
+    balanceGroupedByChain,
     balances,
+    chains,
+    isWalletConnected,
+
     checkIfChainConnected,
     connectKeystore,
     connectWallet,
     disconnectWallet,
     getBalances,
-    isKeystoreDecrypting,
-    isKeystoreOpen,
-    isWalletConnected,
+
     // Keystore related
     keystoreFile,
+
+    isKeystoreDecrypting,
+    isKeystoreOpen,
+
     setIsKeystoreDecrypting,
     setIsKeystoreOpen,
     setKeystoreFile,
-    swapKit,
-    walletType,
   };
 };

--- a/playgrounds/nextjs/src/lib/swapKit.ts
+++ b/playgrounds/nextjs/src/lib/swapKit.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import type { AssetValue, Chain, EVMChain } from "@swapkit/helpers";
-import { NetworkDerivationPath, WalletOption } from "@swapkit/helpers";
+import type { Chain, EVMChain } from "@swapkit/helpers";
+import { AssetValue, NetworkDerivationPath, WalletOption } from "@swapkit/helpers";
 import type { createSwapKit } from "@swapkit/sdk";
 import { atom, useAtom } from "jotai";
 import { useCallback, useEffect, useMemo } from "react";
@@ -23,6 +23,8 @@ export const useSwapKit = () => {
   useEffect(() => {
     const loadSwapKit = async () => {
       const { createSwapKit } = await import("@swapkit/sdk");
+
+      void AssetValue.loadStaticAssets();
 
       const swapKitClient = createSwapKit({
         config: {

--- a/playgrounds/nextjs/tailwind.config.ts
+++ b/playgrounds/nextjs/tailwind.config.ts
@@ -9,7 +9,6 @@ const config = {
     container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
     extend: {
       animation: { "accordion-down": "accordion-down 0.2s ease-out", "accordion-up": "accordion-up 0.2s ease-out" },
-      borderRadius: { lg: "var(--radius)", md: "calc(var(--radius) - 2px)", sm: "calc(var(--radius) - 4px)" },
       colors: {
         accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
         background: "hsl(var(--background))",

--- a/playgrounds/nextjs/tailwind.config.ts
+++ b/playgrounds/nextjs/tailwind.config.ts
@@ -9,19 +9,25 @@ const config = {
     container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
     extend: {
       animation: { "accordion-down": "accordion-down 0.2s ease-out", "accordion-up": "accordion-up 0.2s ease-out" },
+      // biome-ignore assist/source/useSortedKeys: sort by use case, not alphabetically
       colors: {
-        accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
         background: "hsl(var(--background))",
-        border: "hsl(var(--border))",
-        card: { DEFAULT: "hsl(var(--card))", foreground: "hsl(var(--card-foreground))" },
-        destructive: { DEFAULT: "hsl(var(--destructive))", foreground: "hsl(var(--destructive-foreground))" },
         foreground: "hsl(var(--foreground))",
-        input: "hsl(var(--input))",
-        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
-        popover: { DEFAULT: "hsl(var(--popover))", foreground: "hsl(var(--popover-foreground))" },
+
         primary: { DEFAULT: "hsl(var(--primary))", foreground: "hsl(var(--primary-foreground))" },
-        ring: "hsl(var(--ring))",
         secondary: { DEFAULT: "hsl(var(--secondary))", foreground: "hsl(var(--secondary-foreground))" },
+        tertiary: { DEFAULT: "hsl(var(--tertiary))", foreground: "hsl(var(--tertiary-foreground))" },
+
+        accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
+        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
+        destructive: { DEFAULT: "hsl(var(--destructive))", foreground: "hsl(var(--destructive-foreground))" },
+
+        border: "hsl(var(--border))",
+        ring: "hsl(var(--ring))",
+        input: "hsl(var(--input))",
+
+        card: { DEFAULT: "hsl(var(--card))", foreground: "hsl(var(--card-foreground))" },
+        popover: { DEFAULT: "hsl(var(--popover))", foreground: "hsl(var(--popover-foreground))" },
       },
       keyframes: {
         "accordion-down": { from: { height: "0" }, to: { height: "var(--radix-accordion-content-height)" } },


### PR DESCRIPTION
### Done:
- [x] implemented big chunk of swap widget UI based on designs
- [x] added another set of css variables for theming
- [x] started extracting pieces of UI into components (temporarily putting them in one file due to coupling)
- [x] added call to load assets on AssetValue when swapkit is loaded

### Notes:
- we currently show the same image for both chain and ticker logos, need to improve it at some point
- we can start slowly moving things to `ui`, but for that to happen we need to also move `tailwind` and `shadcn/ui` components that we currently hold in `playgrounds/nextjs/src/components/ui`

at some point we'll need to:
1. move `playgrounds/nextjs/src/components/ui` to `@swapkit/ui/*` (probably react?)
2. move swap widget components from `playgrounds/nextjs` to `@swpakit/ui/react` (currently kept in single file)
3. remove tailwind/shadcnui-related deps from playgrounds, use `@swapkit/ui/*` imports exclusively

### Demo
<img width="1107" height="607" alt="image" src="https://github.com/user-attachments/assets/06ab0f22-6285-49c4-892f-4fc43a91bea5" />
<img width="1073" height="605" alt="image" src="https://github.com/user-attachments/assets/89f1e377-1acd-4f11-a04c-d5170a4e031d" />