### PR TITLE
fix: fix biome tailwind css lint issue in packages/ui

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,6 +17,7 @@
       "!**/node_modules",
       "!**/dist",
       "!**/playgrounds",
+      "!**/packages/ui/**/*.css",
       "!**/coverage",
       "!**/MsgCompiled.ts",
       "!**/.astro",


### PR DESCRIPTION
Biome is not configured to deal with tailwind directives in .css files. We didn't have problems with it previously, because we only used tailwind in `playgrounds/*`, which were ignored in `biome.json`

### Done:
- [x] ignore `packages/ui/**/*.css` paths temporarily

### Next:
When biome team releases a fix in `2.3.x` version we'll be able to get rid of these ignore exceptions in `packages/ui` and also in `playgrounds/*` apps https://github.com/biomejs/biome/issues/7223#issuecomment-3291741981