### PR TITLE
feat: add `sk-ui-` prefix to widget's tailwindcss config, update @swapkit/ui to use prefixed classNames

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "swapkit-monorepo",
@@ -297,7 +297,7 @@
         "react": "19.1.1",
         "react-hook-form": "7.65.0",
         "sonner": "2.0.7",
-        "tailwind-merge": "3.3.1",
+        "tailwind-merge": "2.6.0",
         "tailwindcss": "3.4.18",
         "tailwindcss-animate": "1.0.7",
         "ts-pattern": "5.9.0",
@@ -311,6 +311,10 @@
       "dependencies": {
         "@swapkit/helpers": "workspace:*",
       },
+    },
+    "packages/wallet-extension": {
+      "name": "wallet-extension",
+      "version": "0.0.0",
     },
     "packages/wallet-extensions": {
       "name": "@swapkit/wallet-extensions",
@@ -491,7 +495,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-hook-form": "7.65.0",
-        "tailwind-merge": "3.3.1",
+        "tailwind-merge": "2.6.0",
         "tailwindcss": "3.4.18",
         "tailwindcss-animate": "1.0.7",
         "zod": "3.25.74",
@@ -543,7 +547,7 @@
         "sonner": "2.0.7",
         "stream-browserify": "3.0.0",
         "stream-http": "3.2.0",
-        "tailwind-merge": "3.3.1",
+        "tailwind-merge": "2.6.0",
         "tailwindcss-animate": "1.0.7",
         "ts-pattern": "5.9.0",
         "url": "0.11.4",
@@ -591,6 +595,10 @@
         "vite-plugin-top-level-await": "1.6.0",
         "vite-plugin-wasm": "3.5.0",
       },
+    },
+    "playgrounds/vite-lite": {
+      "name": "vite-lite",
+      "version": "0.0.0",
     },
     "tools/builder": {
       "name": "@internal/tools-builder",
@@ -4273,7 +4281,7 @@
 
     "table-layout": ["table-layout@1.0.2", "", { "dependencies": { "array-back": "^4.0.1", "deep-extend": "~0.6.0", "typical": "^5.2.0", "wordwrapjs": "^4.0.0" } }, "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A=="],
 
-    "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
+    "tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
     "tailwindcss": ["tailwindcss@3.4.18", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ=="],
 
@@ -4535,6 +4543,8 @@
 
     "vite": ["vite@7.1.10", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA=="],
 
+    "vite-lite": ["vite-lite@workspace:playgrounds/vite-lite"],
+
     "vite-plugin-node-polyfills": ["vite-plugin-node-polyfills@0.24.0", "", { "dependencies": { "@rollup/plugin-inject": "^5.0.5", "node-stdlib-browser": "^1.2.0" }, "peerDependencies": { "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw=="],
 
     "vite-plugin-top-level-await": ["vite-plugin-top-level-await@1.6.0", "", { "dependencies": { "@rollup/plugin-virtual": "^3.0.2", "@swc/core": "^1.12.14", "@swc/wasm": "^1.12.14", "uuid": "10.0.0" }, "peerDependencies": { "vite": ">=2.8" } }, "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww=="],
@@ -4578,6 +4588,8 @@
     "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
+    "wallet-extension": ["wallet-extension@workspace:packages/wallet-extension"],
 
     "watchpack": ["watchpack@2.4.4", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA=="],
 
@@ -4854,8 +4866,6 @@
     "@meshsdk/bitcoin/bip174": ["bip174@3.0.0", "", { "dependencies": { "uint8array-tools": "^0.0.9", "varuint-bitcoin": "^2.0.0" } }, "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw=="],
 
     "@meshsdk/bitcoin/bip32": ["bip32@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "@scure/base": "^1.1.1", "typeforce": "^1.11.5", "wif": "^2.0.6" } }, "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ=="],
-
-    "@meshsdk/react/tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
     "@meshsdk/web3-sdk/@meshsdk/bitcoin": ["@meshsdk/bitcoin@1.9.0-beta.68", "", { "dependencies": { "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3", "bip174": "^3.0.0-rc.1", "bip32": "^4.0.0", "bip39": "^3.1.0", "bitcoinjs-lib": "^6.1.7", "ecpair": "^2.0.0" } }, "sha512-Ni050tWpSR9GABYVgoB/3tOtINJElg8+A4BWsqU0Ez/HK0AJBxLj+/gKAwzIAsOw0utcxd7mgADFUjXZU+oDlQ=="],
 
@@ -5260,6 +5270,8 @@
     "@stacks/transactions/@noble/hashes": ["@noble/hashes@1.1.5", "", {}, "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="],
 
     "@stacks/transactions/@noble/secp256k1": ["@noble/secp256k1@1.7.1", "", {}, "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="],
+
+    "@swapkit/wallet-hardware/@ledgerhq/hw-transport": ["@ledgerhq/hw-transport@6.31.13", "", { "dependencies": { "@ledgerhq/devices": "8.7.0", "@ledgerhq/errors": "^6.27.0", "@ledgerhq/logs": "^6.13.0", "events": "^3.3.0" } }, "sha512-MrJRDk74wY980ofiFPRpTHQBbRw1wDuKbdag1zqlO1xtJglymwwY03K2kvBNvkm1RTSCPUp/nAoNG+WThZuuew=="],
 
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -6760,8 +6772,6 @@
     "@meshsdk/web3-sdk/@meshsdk/bitcoin/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@meshsdk/web3-sdk/@meshsdk/core/@meshsdk/react/@meshsdk/web3-sdk": ["@meshsdk/web3-sdk@0.0.37", "", { "dependencies": { "@meshsdk/bitcoin": "1.9.0-beta.53", "@meshsdk/common": "1.9.0-beta.53", "@meshsdk/core-cst": "1.9.0-beta.53", "@meshsdk/wallet": "1.9.0-beta.53", "@peculiar/webcrypto": "^1.5.0", "axios": "^1.8.3", "base32-encoding": "^1.0.0", "uuid": "^11.1.0" } }, "sha512-uRG0jLjsa83JbPZqnVkec3gjvi0LEMiu1E6ItUALEnKUTTuhDOe3Cx4Ov1PbPTsYVsGRq61DCgzCNHSh2bXy+Q=="],
-
-    "@meshsdk/web3-sdk/@meshsdk/core/@meshsdk/react/tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
     "@meteorwallet/sdk/@near-js/accounts/@near-js/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,7 @@
     "react": "19.1.1",
     "react-hook-form": "7.65.0",
     "sonner": "2.0.7",
-    "tailwind-merge": "3.3.1",
+    "tailwind-merge": "2.6.0",
     "tailwindcss": "3.4.18",
     "tailwindcss-animate": "1.0.7",
     "ts-pattern": "5.9.0",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,8 +1,11 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+import tailwindConfig from "../../tailwind.config";
+
+const twMergeWithPrefix = extendTailwindMerge({ prefix: tailwindConfig.prefix });
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMergeWithPrefix(clsx(inputs));
 }
 
 export function formatCurrency(amount: number | null) {

--- a/packages/ui/src/react/components/asset-icon.tsx
+++ b/packages/ui/src/react/components/asset-icon.tsx
@@ -20,10 +20,10 @@ export function AssetIcon({ asset, className }: AssetIconProps) {
   const assetValue = AssetValue.from({ asset });
 
   return (
-    <div className={cn("relative size-10", className)}>
+    <div className={cn("sk-ui-relative sk-ui-size-10", className)}>
       <img
         alt={assetValue?.ticker}
-        className={"size-full overflow-hidden rounded-full"}
+        className={"sk-ui-size-full sk-ui-overflow-hidden sk-ui-rounded-full"}
         height={40}
         src={`${temp_host}/images/${assetValue?.chain?.toLowerCase()}.${assetValue?.symbol?.toLowerCase()}.png`}
         width={40}
@@ -32,7 +32,7 @@ export function AssetIcon({ asset, className }: AssetIconProps) {
       {assetValue?.type !== "Native" && (
         <img
           alt={assetValue?.chain}
-          className="-bottom-0.5 absolute right-0 size-[45%] rounded-full border-2 border-secondary bg-secondary"
+          className="sk-ui--bottom-0.5 sk-ui-absolute sk-ui-right-0 sk-ui-size-[45%] sk-ui-rounded-full sk-ui-border-2 sk-ui-border-secondary sk-ui-bg-secondary"
           height={24}
           src={`${temp_host}/images/${assetValue?.chain?.toLowerCase()}.${assetValue?.chainId?.toLowerCase()}.png`}
           width={24}

--- a/packages/ui/src/react/components/chain-icon.tsx
+++ b/packages/ui/src/react/components/chain-icon.tsx
@@ -16,13 +16,13 @@ export function ChainIcon({ chain, className }: ChainIconProps) {
 
   if (!iconUrl) {
     return (
-      <div className={cn("flex items-center justify-center rounded-full bg-card font-medium text-xs", className)}>
+      <div className={cn("sk-ui-flex sk-ui-items-center sk-ui-justify-center sk-ui-rounded-full sk-ui-bg-card sk-ui-font-medium sk-ui-text-xs", className)}>
         {chain?.slice(0, 2)}
       </div>
     );
   }
 
   return (
-    <img alt={chain} className={cn("rounded-full object-contain", className)} height={24} src={iconUrl} width={24} />
+    <img alt={chain} className={cn("sk-ui-rounded-full sk-ui-object-contain", className)} height={24} src={iconUrl} width={24} />
   );
 }

--- a/packages/ui/src/react/components/composable/swap-amount-input.tsx
+++ b/packages/ui/src/react/components/composable/swap-amount-input.tsx
@@ -18,9 +18,9 @@ export function SwapAmountInput({
   setAmount?: (amount: string) => void;
 }) {
   return (
-    <div className={cn("flex flex-col items-end", className)}>
+    <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-items-end", className)}>
       <Input
-        className="-mr-3 !shadow-none !border-0 !ring-0 !ring-offset-0 bg-transparent text-end font-medium text-2xl"
+        className="sk-ui--mr-3 !shadow-none !border-0 !ring-0 !ring-offset-0 sk-ui-bg-transparent sk-ui-text-end sk-ui-font-medium sk-ui-text-2xl"
         disabled={disabled}
         onChange={(e) => setAmount?.(e.target.value)}
         placeholder="0.00"
@@ -28,10 +28,10 @@ export function SwapAmountInput({
         value={amount ?? "0.00"}
       />
 
-      <div className="flex items-center gap-1">
-        {isLoading && <Loader2Icon className="size-3.5 animate-spin" />}
+      <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-1">
+        {isLoading && <Loader2Icon className="sk-ui-size-3.5 sk-ui-animate-spin" />}
 
-        <span className="text-muted-foreground text-sm">{formattedAmountUSD}</span>
+        <span className="sk-ui-text-muted-foreground sk-ui-text-sm">{formattedAmountUSD}</span>
       </div>
     </div>
   );

--- a/packages/ui/src/react/components/composable/swap-amount-input.tsx
+++ b/packages/ui/src/react/components/composable/swap-amount-input.tsx
@@ -20,7 +20,7 @@ export function SwapAmountInput({
   return (
     <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-items-end", className)}>
       <Input
-        className="sk-ui--mr-3 !shadow-none !border-0 !ring-0 !ring-offset-0 sk-ui-bg-transparent sk-ui-text-end sk-ui-font-medium sk-ui-text-2xl"
+        className="sk-ui--mr-3 !sk-ui-shadow-none !sk-ui-border-0 !sk-ui-ring-0 !sk-ui-ring-offset-0 sk-ui-bg-transparent sk-ui-text-end sk-ui-font-medium sk-ui-text-2xl"
         disabled={disabled}
         onChange={(e) => setAmount?.(e.target.value)}
         placeholder="0.00"

--- a/packages/ui/src/react/components/composable/swap-asset-item.tsx
+++ b/packages/ui/src/react/components/composable/swap-asset-item.tsx
@@ -9,13 +9,13 @@ export function SwapAssetItem({ asset }: { asset: string | null | undefined }) {
   const assetValue = AssetValue.from({ asset });
 
   return (
-    <div className="flex min-w-0 items-center gap-3">
+    <div className="sk-ui-flex sk-ui-min-w-0 sk-ui-items-center sk-ui-gap-3">
       <AssetIcon asset={asset} />
 
-      <div className="flex min-w-0 flex-col items-start">
-        <span className="max-w-full truncate font-medium text-base text-foreground">{assetValue?.ticker}</span>
+      <div className="sk-ui-flex sk-ui-min-w-0 sk-ui-flex-col sk-ui-items-start">
+        <span className="sk-ui-max-w-full sk-ui-truncate sk-ui-font-medium sk-ui-text-base sk-ui-text-foreground">{assetValue?.ticker}</span>
 
-        <span className="-mt-0.5 text-muted-foreground text-sm">{assetValue?.chain}</span>
+        <span className="sk-ui--mt-0.5 sk-ui-text-muted-foreground sk-ui-text-sm">{assetValue?.chain}</span>
       </div>
     </div>
   );

--- a/packages/ui/src/react/components/composable/swap-asset-select.tsx
+++ b/packages/ui/src/react/components/composable/swap-asset-select.tsx
@@ -95,7 +95,7 @@ export function SwapAssetSelect({
           <div className="sk-ui-grid sk-ui-grid-cols-8 sk-ui-gap-2">
             <Button
               className={cn(
-                "aspect-[1.3/1] sk-ui-h-auto sk-ui-border sk-ui-border-transparent",
+                "sk-ui-h-auto sk-ui-border sk-ui-border-transparent sk-ui-aspect-[1.3/1]",
                 selectedNetworks?.length === 0 && "sk-ui-border-foreground sk-ui-text-foreground",
               )}
               onClick={() => setSelectedNetworks([])}>
@@ -108,7 +108,7 @@ export function SwapAssetSelect({
               return (
                 <Button
                   className={cn(
-                    "aspect-[1.3/1] sk-ui-h-auto sk-ui-border sk-ui-border-transparent sk-ui-p-0",
+                    "sk-ui-h-auto sk-ui-border sk-ui-border-transparent sk-ui-p-0 sk-ui-aspect-[1.3/1]",
                     isSelected && "sk-ui-border-foreground sk-ui-text-foreground",
                   )}
                   key={`swap-asset-network-${chain}`}
@@ -136,13 +136,15 @@ export function SwapAssetSelect({
           </div>
         </div>
 
-        <DialogFooter className="sk-ui-mt-2 max-h-[clamp(16rem,50svh,32rem)] sk-ui-overflow-y-auto sk-ui-overflow-x-hidden">
+        <DialogFooter className="sk-ui-mt-2 sk-ui-overflow-y-auto sk-ui-overflow-x-hidden sk-ui-max-h-[clamp(16rem,50svh,32rem)]">
           {match({ assets, isWalletConnected })
             .with({ isWalletConnected: false }, () => (
               <div className="sk-ui-flex sk-ui-h-40 sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1">
                 <header className="sk-ui-font-medium">Connect your wallet</header>
 
-                <p className="sk-ui-text-muted-foreground sk-ui-text-sm">Please connect your wallet to see your assets</p>
+                <p className="sk-ui-text-muted-foreground sk-ui-text-sm">
+                  Please connect your wallet to see your assets
+                </p>
               </div>
             ))
             .when(
@@ -173,7 +175,11 @@ export function SwapAssetSelect({
                       variant="ghost">
                       <SwapAssetItem asset={assetIdentifier} />
 
-                      <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-items-end", asset?.getValue("number") <= 0 && "opacity-50")}>
+                      <div
+                        className={cn(
+                          "sk-ui-flex sk-ui-flex-col sk-ui-items-end",
+                          asset?.getValue("number") <= 0 && "sk-ui-opacity-50",
+                        )}>
                         <span className="sk-ui-font-medium sk-ui-text-base sk-ui-text-foreground">
                           {asset?.getValue("number")?.toFixed(6) || "0.00"}
                         </span>

--- a/packages/ui/src/react/components/composable/swap-asset-select.tsx
+++ b/packages/ui/src/react/components/composable/swap-asset-select.tsx
@@ -63,40 +63,40 @@ export function SwapAssetSelect({
   return (
     <Dialog onOpenChange={setOpen} open={open}>
       <DialogTrigger
-        className="-ml-2 mt-1 w-auto min-w-48 max-w-1/2 rounded-lg px-2 transition-colors duration-100 hover:bg-white/[0.08]"
+        className="sk-ui--ml-2 sk-ui-mt-1 sk-ui-w-auto sk-ui-min-w-48 sk-ui-max-w-1/2 sk-ui-rounded-lg sk-ui-px-2 sk-ui-transition-colors sk-ui-duration-100 hover:sk-ui-bg-white/[0.08]"
         onClick={handleDialogTriggerClick}>
         <SwapAssetItem asset={selectedAsset} />
       </DialogTrigger>
 
-      <DialogContent className="flex flex-col">
+      <DialogContent className="sk-ui-flex sk-ui-flex-col">
         <DialogHeader>
           <DialogTitle>Select Token</DialogTitle>
         </DialogHeader>
 
-        <div className="relative">
+        <div className="sk-ui-relative">
           <Input
-            className="h-10 bg-secondary pl-9 placeholer:text-muted-foreground text-base text-foreground"
+            className="sk-ui-h-10 sk-ui-bg-secondary sk-ui-pl-9 placeholer:sk-ui-text-muted-foreground sk-ui-text-base sk-ui-text-foreground"
             onChange={(e) => setFilters({ searchQuery: e.target.value })}
             placeholder="Search token name"
             value={filters?.searchQuery ?? ""}
           />
 
-          <SearchIcon className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground" />
+          <SearchIcon className="sk-ui--translate-y-1/2 sk-ui-absolute sk-ui-top-1/2 sk-ui-left-3 sk-ui-size-4 sk-ui-text-muted-foreground" />
         </div>
 
-        <div className="flex flex-col gap-2">
-          <span className="text-muted-foreground text-sm">
+        <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2">
+          <span className="sk-ui-text-muted-foreground sk-ui-text-sm">
             Network:{" "}
-            <span className="font-medium text-foreground">
+            <span className="sk-ui-font-medium sk-ui-text-foreground">
               {selectedNetworks?.length ? selectedNetworks?.map((network) => network.toString()).join(", ") : "All"}
             </span>
           </span>
 
-          <div className="grid grid-cols-8 gap-2">
+          <div className="sk-ui-grid sk-ui-grid-cols-8 sk-ui-gap-2">
             <Button
               className={cn(
-                "aspect-[1.3/1] h-auto border border-transparent",
-                selectedNetworks?.length === 0 && "border-foreground text-foreground",
+                "aspect-[1.3/1] sk-ui-h-auto sk-ui-border sk-ui-border-transparent",
+                selectedNetworks?.length === 0 && "sk-ui-border-foreground sk-ui-text-foreground",
               )}
               onClick={() => setSelectedNetworks([])}>
               All
@@ -108,8 +108,8 @@ export function SwapAssetSelect({
               return (
                 <Button
                   className={cn(
-                    "aspect-[1.3/1] h-auto border border-transparent p-0",
-                    isSelected && "border-foreground text-foreground",
+                    "aspect-[1.3/1] sk-ui-h-auto sk-ui-border sk-ui-border-transparent sk-ui-p-0",
+                    isSelected && "sk-ui-border-foreground sk-ui-text-foreground",
                   )}
                   key={`swap-asset-network-${chain}`}
                   onClick={() => {
@@ -121,14 +121,14 @@ export function SwapAssetSelect({
                       return Array.from(new Set([...selectedNetworks, chain]));
                     });
                   }}>
-                  <ChainIcon chain={chain} className="size-5" />
+                  <ChainIcon chain={chain} className="sk-ui-size-5" />
                 </Button>
               );
             })}
 
             {canShowMore && (
               <Button
-                className="col-span-2 col-start-7 h-auto"
+                className="sk-ui-col-span-2 sk-ui-col-start-7 sk-ui-h-auto"
                 onClick={() => setIsNetworkListExpanded((isNetworkListExpanded) => !isNetworkListExpanded)}>
                 {isNetworkListExpanded ? "Hide" : "Show More"}
               </Button>
@@ -136,35 +136,35 @@ export function SwapAssetSelect({
           </div>
         </div>
 
-        <DialogFooter className="mt-2 max-h-[clamp(16rem,50svh,32rem)] overflow-y-auto overflow-x-hidden">
+        <DialogFooter className="sk-ui-mt-2 max-h-[clamp(16rem,50svh,32rem)] sk-ui-overflow-y-auto sk-ui-overflow-x-hidden">
           {match({ assets, isWalletConnected })
             .with({ isWalletConnected: false }, () => (
-              <div className="flex h-40 flex-col items-center justify-center gap-1">
-                <header className="font-medium">Connect your wallet</header>
+              <div className="sk-ui-flex sk-ui-h-40 sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1">
+                <header className="sk-ui-font-medium">Connect your wallet</header>
 
-                <p className="text-muted-foreground text-sm">Please connect your wallet to see your assets</p>
+                <p className="sk-ui-text-muted-foreground sk-ui-text-sm">Please connect your wallet to see your assets</p>
               </div>
             ))
             .when(
               ({ assets }) => assets?.length <= 0,
               () => (
-                <div className="flex h-40 flex-col items-center justify-center gap-1">
-                  <header className="font-medium">No assets found</header>
+                <div className="sk-ui-flex sk-ui-h-40 sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1">
+                  <header className="sk-ui-font-medium">No assets found</header>
 
-                  <p className="text-muted-foreground text-sm">
+                  <p className="sk-ui-text-muted-foreground sk-ui-text-sm">
                     Try changing the selected networks or the search query
                   </p>
                 </div>
               ),
             )
             .otherwise(() => (
-              <div className="flex w-auto flex-1 flex-col">
+              <div className="sk-ui-flex sk-ui-w-auto sk-ui-flex-1 sk-ui-flex-col">
                 {assets?.slice(0, 100)?.map((asset) => {
                   const assetIdentifier = asset.toString();
 
                   return (
                     <Button
-                      className="-mx-4 h-auto w-auto justify-between rounded-lg px-4 py-2"
+                      className="sk-ui--mx-4 sk-ui-h-auto sk-ui-w-auto sk-ui-justify-between sk-ui-rounded-lg sk-ui-px-4 sk-ui-py-2"
                       key={`swap-asset-item-${assetIdentifier}-${asset.chainId}`}
                       onClick={() => {
                         setSelectedAsset(assetIdentifier);
@@ -173,12 +173,12 @@ export function SwapAssetSelect({
                       variant="ghost">
                       <SwapAssetItem asset={assetIdentifier} />
 
-                      <div className={cn("flex flex-col items-end", asset?.getValue("number") <= 0 && "opacity-50")}>
-                        <span className="font-medium text-base text-foreground">
+                      <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-items-end", asset?.getValue("number") <= 0 && "opacity-50")}>
+                        <span className="sk-ui-font-medium sk-ui-text-base sk-ui-text-foreground">
                           {asset?.getValue("number")?.toFixed(6) || "0.00"}
                         </span>
 
-                        <span className="-mt-0.5 text-muted-foreground text-sm">
+                        <span className="sk-ui--mt-0.5 sk-ui-text-muted-foreground sk-ui-text-sm">
                           {/* TODO: show the correct USD balance value */}
                           {formatCurrency(asset?.getValue("number") || 0)}
                         </span>

--- a/packages/ui/src/react/components/composable/swap-input-chain-selector.tsx
+++ b/packages/ui/src/react/components/composable/swap-input-chain-selector.tsx
@@ -31,10 +31,10 @@ export function SwapInputWithChainSelector({
   const isInputDisabled = !selectedAsset || isSwapping || isLoading || !setAmount;
 
   return (
-    <div className="-my-2">
-      <span className="text-muted-foreground text-xs">{label}</span>
+    <div className="sk-ui--my-2">
+      <span className="sk-ui-text-muted-foreground sk-ui-text-xs">{label}</span>
 
-      <div className="flex justify-between">
+      <div className="sk-ui-flex sk-ui-justify-between">
         <SwapAssetSelect selectedAsset={selectedAsset} setSelectedAsset={setSelectedAsset} />
 
         <SwapAmountInput

--- a/packages/ui/src/react/components/composable/swap-quote-preview.tsx
+++ b/packages/ui/src/react/components/composable/swap-quote-preview.tsx
@@ -37,25 +37,25 @@ export function SwapQuotePreview({
 
   return (
     <Card className={className}>
-      <CardContent className="fade-in-0 flex animate-in flex-col items-stretch duration-300">
+      <CardContent className="sk-ui-fade-in-0 sk-ui-flex sk-ui-animate-in sk-ui-flex-col sk-ui-items-stretch sk-ui-duration-300">
         <Button
-          className="-mt-4 -mx-4 flex rounded-t-xl rounded-b-none px-4 py-3 hover:bg-white/[0.08]"
+          className="sk-ui--mt-4 sk-ui--mx-4 sk-ui-flex sk-ui-rounded-t-xl sk-ui-rounded-b-none sk-ui-px-4 sk-ui-py-3 hover:sk-ui-bg-white/[0.08]"
           onClick={selectQuoteRoute}
           variant="unstyled">
-          <CardHeader className="flex w-full flex-row items-center space-y-0 text-sm">
-            <div className="flex items-center gap-2">
+          <CardHeader className="sk-ui-flex sk-ui-w-full sk-ui-flex-row sk-ui-items-center sk-ui-space-y-0 sk-ui-text-sm">
+            <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
               {selectedRoute?.providerName && (
                 <img
                   alt={selectedRoute?.providerName}
-                  className="size-6 rounded-full bg-primary"
+                  className="sk-ui-size-6 sk-ui-rounded-full sk-ui-bg-primary"
                   src={selectedRoute?.providerLogoURI ?? ""}
                 />
               )}
 
-              <div className="font-medium">{selectedRoute?.providerName}</div>
+              <div className="sk-ui-font-medium">{selectedRoute?.providerName}</div>
 
               {selectedRouteHasTags && (
-                <div className="rounded bg-success px-1 py-0.5 text-success-foreground text-xs">
+                <div className="sk-ui-rounded sk-ui-bg-success sk-ui-px-1 sk-ui-py-0.5 sk-ui-text-success-foreground sk-ui-text-xs">
                   {match(selectedRoute?.tags)
                     .when(
                       (tags) => tags?.includes(PriorityLabel.RECOMMENDED),
@@ -74,82 +74,82 @@ export function SwapQuotePreview({
               )}
             </div>
 
-            <div className="!ml-auto mr-4 flex items-center gap-1 text-muted-foreground text-sm">
-              <TimerIcon className="size-4" />
+            <div className="!ml-auto sk-ui-mr-4 sk-ui-flex sk-ui-items-center sk-ui-gap-1 sk-ui-text-muted-foreground sk-ui-text-sm">
+              <TimerIcon className="sk-ui-size-4" />
 
-              <span className="font-normal">{selectedRoute?.formattedEstimatedTime}</span>
+              <span className="sk-ui-font-normal">{selectedRoute?.formattedEstimatedTime}</span>
             </div>
 
-            <div className="font-medium text-foreground">
+            <div className="sk-ui-font-medium sk-ui-text-foreground">
               {selectedRoute?.expectedBuyAmount} {selectedRoute?.outputAssetTicker}
             </div>
 
-            <ChevronRight className="ml-2 size-4 text-foreground" />
+            <ChevronRight className="sk-ui-ml-2 sk-ui-size-4 sk-ui-text-foreground" />
           </CardHeader>
         </Button>
 
         <Accordion collapsible type="single">
-          <AccordionItem className="-mb-4 -mx-4" value="quote">
-            <AccordionTrigger className="flex items-center rounded-b-lg border-card border-r border-b border-l bg-background p-4 text-sm hover:bg-background/50 hover:no-underline data-[state=open]:rounded-b-none data-[state=open]:border-b-transparent">
-              <ArrowLeftRight className="size-4 text-muted-foreground" />
+          <AccordionItem className="sk-ui--mb-4 sk-ui--mx-4" value="quote">
+            <AccordionTrigger className="sk-ui-flex sk-ui-items-center sk-ui-rounded-b-lg sk-ui-border-card sk-ui-border-r sk-ui-border-b sk-ui-border-l sk-ui-bg-background sk-ui-p-4 sk-ui-text-sm hover:sk-ui-bg-background/50 hover:sk-ui-no-underline data-[state=open]:sk-ui-rounded-b-none data-[state=open]:sk-ui-border-b-transparent">
+              <ArrowLeftRight className="sk-ui-size-4 sk-ui-text-muted-foreground" />
 
-              <span className="ml-2">
+              <span className="sk-ui-ml-2">
                 1 {selectedRoute?.inputAssetTicker} ≈ {selectedRoute?.expectedBuyAmountFor1Input.toFixed(6)}{" "}
                 {selectedRoute?.outputAssetTicker}
               </span>
 
-              <span className="mr-2 ml-auto font-medium">Fees: {selectedRoute?.formattedTotalFeesUSD}</span>
+              <span className="sk-ui-mr-2 sk-ui-ml-auto sk-ui-font-medium">Fees: {selectedRoute?.formattedTotalFeesUSD}</span>
             </AccordionTrigger>
 
-            <AccordionContent className="rounded-b-lg border-card border-r border-b border-l bg-background px-4 pb-4 duration-150">
-              <ul className="flex flex-col gap-2 text-muted-foreground">
-                <li className="flex items-center gap-1">
+            <AccordionContent className="sk-ui-rounded-b-lg sk-ui-border-card sk-ui-border-r sk-ui-border-b sk-ui-border-l sk-ui-bg-background sk-ui-px-4 sk-ui-pb-4 sk-ui-duration-150">
+              <ul className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2 sk-ui-text-muted-foreground">
+                <li className="sk-ui-flex sk-ui-items-center sk-ui-gap-1">
                   <span>Minimum received after slippage ({selectedRoute?.formattedMaxSlippagePercentage})</span>
 
-                  <InfoIcon className="size-4" />
+                  <InfoIcon className="sk-ui-size-4" />
 
-                  <span className="ml-auto font-medium text-foreground">
+                  <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">
                     {selectedRoute?.expectedBuyAmountMaxSlippage} {selectedRoute?.outputAssetTicker}
                   </span>
                 </li>
 
-                <li className="flex items-center gap-1">
+                <li className="sk-ui-flex sk-ui-items-center sk-ui-gap-1">
                   <span>Liquidity fee</span>
 
-                  <InfoIcon className="size-4" />
+                  <InfoIcon className="sk-ui-size-4" />
 
                   {selectedRoute?.formattedLiquidityFeeUSD === "$0.00" ? (
-                    <span className="ml-auto font-medium text-success-foreground">FREE</span>
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-success-foreground">FREE</span>
                   ) : (
-                    <span className="ml-auto font-medium text-foreground">
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">
                       {selectedRoute?.formattedLiquidityFeeUSD}
                     </span>
                   )}
                 </li>
 
-                <li className="flex items-center gap-1">
+                <li className="sk-ui-flex sk-ui-items-center sk-ui-gap-1">
                   <span>Exchange fee</span>
 
-                  <InfoIcon className="size-4" />
+                  <InfoIcon className="sk-ui-size-4" />
 
                   {selectedRoute?.formattedExchangeFeeUSD === "$0.00" ? (
-                    <span className="ml-auto font-medium text-success-foreground">FREE</span>
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-success-foreground">FREE</span>
                   ) : (
-                    <span className="ml-auto font-medium text-foreground">
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">
                       {selectedRoute?.formattedExchangeFeeUSD}
                     </span>
                   )}
                 </li>
 
-                <li className="flex items-center gap-1">
+                <li className="sk-ui-flex sk-ui-items-center sk-ui-gap-1">
                   <span>Inbound network fee</span>
 
-                  <InfoIcon className="size-4" />
+                  <InfoIcon className="sk-ui-size-4" />
 
                   {selectedRoute?.formattedInboundNetworkFeeUSD === "$0.00" ? (
-                    <span className="ml-auto font-medium text-success-foreground">FREE</span>
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-success-foreground">FREE</span>
                   ) : (
-                    <span className="ml-auto font-medium text-foreground">
+                    <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">
                       {selectedRoute?.formattedInboundNetworkFeeUSD}
                     </span>
                   )}

--- a/packages/ui/src/react/components/composable/swap-quote-preview.tsx
+++ b/packages/ui/src/react/components/composable/swap-quote-preview.tsx
@@ -74,7 +74,7 @@ export function SwapQuotePreview({
               )}
             </div>
 
-            <div className="!ml-auto sk-ui-mr-4 sk-ui-flex sk-ui-items-center sk-ui-gap-1 sk-ui-text-muted-foreground sk-ui-text-sm">
+            <div className="!sk-ui-ml-auto sk-ui-mr-4 sk-ui-flex sk-ui-items-center sk-ui-gap-1 sk-ui-text-muted-foreground sk-ui-text-sm">
               <TimerIcon className="sk-ui-size-4" />
 
               <span className="sk-ui-font-normal">{selectedRoute?.formattedEstimatedTime}</span>
@@ -98,7 +98,9 @@ export function SwapQuotePreview({
                 {selectedRoute?.outputAssetTicker}
               </span>
 
-              <span className="sk-ui-mr-2 sk-ui-ml-auto sk-ui-font-medium">Fees: {selectedRoute?.formattedTotalFeesUSD}</span>
+              <span className="sk-ui-mr-2 sk-ui-ml-auto sk-ui-font-medium">
+                Fees: {selectedRoute?.formattedTotalFeesUSD}
+              </span>
             </AccordionTrigger>
 
             <AccordionContent className="sk-ui-rounded-b-lg sk-ui-border-card sk-ui-border-r sk-ui-border-b sk-ui-border-l sk-ui-bg-background sk-ui-px-4 sk-ui-pb-4 sk-ui-duration-150">

--- a/packages/ui/src/react/components/dialogs/swap-confirm-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/swap-confirm-dialog.tsx
@@ -45,7 +45,7 @@ export const SwapConfirmDialog = ({
 
             <SwapAmountInput
               amount={swapRoute.amount}
-              className="[&_input]:!opacity-100 [&_input]:!cursor-text"
+              className="[&_input]:!sk-ui-opacity-100 [&_input]:!sk-ui-cursor-text"
               disabled
               formattedAmountUSD={swapRoute.formattedInputAssetPriceUSD}
             />
@@ -54,7 +54,7 @@ export const SwapConfirmDialog = ({
           <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
             <div className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
 
-            <MoveDownIcon className="sk-ui-size-4 sk-ui-shrink-0 stroke-[2.5] sk-ui-font-bold text-[#8b8c8b]" />
+            <MoveDownIcon className="sk-ui-size-4 sk-ui-shrink-0 sk-ui-font-bold sk-ui-stroke-[2.5] sk-ui-text-[#8b8c8b]" />
 
             <div className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
           </div>
@@ -64,7 +64,7 @@ export const SwapConfirmDialog = ({
 
             <SwapAmountInput
               amount={swapRoute?.expectedBuyAmount?.toString()}
-              className="[&_input]:!opacity-100 [&_input]:!cursor-text"
+              className="[&_input]:!sk-ui-opacity-100 [&_input]:!sk-ui-cursor-text"
               disabled
               formattedAmountUSD={swapRoute?.formattedOutputAssetPriceUSD}
             />
@@ -81,16 +81,22 @@ export const SwapConfirmDialog = ({
 
                 <ChevronDown className="sk-ui-mt-px sk-ui-ml-1 sk-ui-size-4" />
 
-                <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">{swapRoute?.formattedTotalFeesUSD}</span>
+                <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">
+                  {swapRoute?.formattedTotalFeesUSD}
+                </span>
               </AccordionTrigger>
 
               <AccordionContent className="sk-ui-mt-3 sk-ui-pb-0">
                 <ul className="sk-ui-flex sk-ui-flex-col sk-ui-gap-3 sk-ui-border-b sk-ui-pb-3">
                   {totalFeesListItems.map((item) => (
-                    <li className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1" key={`total-fee-list-item-${item.title}`}>
+                    <li
+                      className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1"
+                      key={`total-fee-list-item-${item.title}`}>
                       <span className="sk-ui-text-muted-foreground">{item.title}</span>
 
-                      <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">{item.value}</span>
+                      <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">
+                        {item.value}
+                      </span>
                     </li>
                   ))}
                 </ul>
@@ -98,10 +104,14 @@ export const SwapConfirmDialog = ({
 
               <ul className="sk-ui-mt-3 sk-ui-flex sk-ui-flex-col sk-ui-gap-3">
                 {swapSummaryListItems.map((item) => (
-                  <li className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1" key={`swap-list-item-${item.title}`}>
+                  <li
+                    className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1"
+                    key={`swap-list-item-${item.title}`}>
                     <span className="sk-ui-text-muted-foreground">{item.title}</span>
 
-                    <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">{item.value}</span>
+                    <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">
+                      {item.value}
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/packages/ui/src/react/components/dialogs/swap-confirm-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/swap-confirm-dialog.tsx
@@ -39,8 +39,8 @@ export const SwapConfirmDialog = ({
           <DialogTitle>Confirm swap</DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between gap-2">
+        <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2">
+          <div className="sk-ui-flex sk-ui-items-center sk-ui-justify-between sk-ui-gap-2">
             <SwapAssetItem asset={swapRoute?.route?.sellAsset} />
 
             <SwapAmountInput
@@ -51,15 +51,15 @@ export const SwapConfirmDialog = ({
             />
           </div>
 
-          <div className="flex items-center gap-2">
-            <div className="h-px w-full bg-border" />
+          <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
+            <div className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
 
-            <MoveDownIcon className="size-4 shrink-0 stroke-[2.5] font-bold text-[#8b8c8b]" />
+            <MoveDownIcon className="sk-ui-size-4 sk-ui-shrink-0 stroke-[2.5] sk-ui-font-bold text-[#8b8c8b]" />
 
-            <div className="h-px w-full bg-border" />
+            <div className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
           </div>
 
-          <div className="flex items-center justify-between gap-2">
+          <div className="sk-ui-flex sk-ui-items-center sk-ui-justify-between sk-ui-gap-2">
             <SwapAssetItem asset={swapRoute?.route?.buyAsset} />
 
             <SwapAmountInput
@@ -71,37 +71,37 @@ export const SwapConfirmDialog = ({
           </div>
         </div>
 
-        <div className="overflow-hidden rounded-lg border p-4 text-sm">
+        <div className="sk-ui-overflow-hidden sk-ui-rounded-lg sk-ui-border sk-ui-p-4 sk-ui-text-sm">
           <Accordion type="multiple">
             <AccordionItem value="total-fee">
               <AccordionTrigger
-                className="-mx-4 -mt-4 -mb-3 items-center px-4 py-3 text-muted-foreground outline-none duration-150 hover:text-foreground hover:no-underline focus:text-foreground"
+                className="sk-ui--mx-4 sk-ui--mt-4 sk-ui--mb-3 sk-ui-items-center sk-ui-px-4 sk-ui-py-3 sk-ui-text-muted-foreground sk-ui-outline-none sk-ui-duration-150 hover:sk-ui-text-foreground hover:sk-ui-no-underline focus:sk-ui-text-foreground"
                 showChevron={false}>
-                <span className="flex items-center">Total fee</span>
+                <span className="sk-ui-flex sk-ui-items-center">Total fee</span>
 
-                <ChevronDown className="mt-px ml-1 size-4" />
+                <ChevronDown className="sk-ui-mt-px sk-ui-ml-1 sk-ui-size-4" />
 
-                <span className="ml-auto font-medium text-foreground">{swapRoute?.formattedTotalFeesUSD}</span>
+                <span className="sk-ui-ml-auto sk-ui-font-medium sk-ui-text-foreground">{swapRoute?.formattedTotalFeesUSD}</span>
               </AccordionTrigger>
 
-              <AccordionContent className="mt-3 pb-0">
-                <ul className="flex flex-col gap-3 border-b pb-3">
+              <AccordionContent className="sk-ui-mt-3 sk-ui-pb-0">
+                <ul className="sk-ui-flex sk-ui-flex-col sk-ui-gap-3 sk-ui-border-b sk-ui-pb-3">
                   {totalFeesListItems.map((item) => (
-                    <li className="flex items-start justify-between gap-1" key={`total-fee-list-item-${item.title}`}>
-                      <span className="text-muted-foreground">{item.title}</span>
+                    <li className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1" key={`total-fee-list-item-${item.title}`}>
+                      <span className="sk-ui-text-muted-foreground">{item.title}</span>
 
-                      <span className="max-w-[60%] break-all text-right font-medium">{item.value}</span>
+                      <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">{item.value}</span>
                     </li>
                   ))}
                 </ul>
               </AccordionContent>
 
-              <ul className="mt-3 flex flex-col gap-3">
+              <ul className="sk-ui-mt-3 sk-ui-flex sk-ui-flex-col sk-ui-gap-3">
                 {swapSummaryListItems.map((item) => (
-                  <li className="flex items-start justify-between gap-1" key={`swap-list-item-${item.title}`}>
-                    <span className="text-muted-foreground">{item.title}</span>
+                  <li className="sk-ui-flex sk-ui-items-start sk-ui-justify-between sk-ui-gap-1" key={`swap-list-item-${item.title}`}>
+                    <span className="sk-ui-text-muted-foreground">{item.title}</span>
 
-                    <span className="max-w-[60%] break-all text-right font-medium">{item.value}</span>
+                    <span className="sk-ui-max-w-[60%] sk-ui-break-all sk-ui-text-right sk-ui-font-medium">{item.value}</span>
                   </li>
                 ))}
               </ul>

--- a/packages/ui/src/react/components/dialogs/swap-quote-route-select-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/swap-quote-route-select-dialog.tsx
@@ -23,29 +23,29 @@ export const SwapQuoteRouteSelectDialog = ({
           <DialogTitle>Select provider</DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-2">
+        <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2">
           {routes?.map((route) => (
             <Button
               className={cn(
-                "h-auto w-full justify-start p-4",
-                route?.routeIndex === selectedRoute?.routeIndex && "ring-2 ring-white/[0.64]",
+                "sk-ui-h-auto sk-ui-w-full sk-ui-justify-start sk-ui-p-4",
+                route?.routeIndex === selectedRoute?.routeIndex && "sk-ui-ring-2 sk-ui-ring-white/[0.64]",
               )}
               key={`swap-quote-route-${route?.providerName}`}
               onClick={() => modal.resolve({ confirmed: true, data: route?.routeIndex })}>
               {route?.providerName && (
                 <img
                   alt={route?.providerName}
-                  className="size-10 rounded-full bg-primary"
+                  className="sk-ui-size-10 sk-ui-rounded-full sk-ui-bg-primary"
                   src={route?.providerLogoURI ?? ""}
                 />
               )}
 
-              <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-base text-foreground">{route?.providerName}</span>
+              <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-1">
+                <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
+                  <span className="sk-ui-font-medium sk-ui-text-base sk-ui-text-foreground">{route?.providerName}</span>
 
                   {route?.tags?.length > 0 && (
-                    <div className="rounded bg-success px-1 py-0.5 text-success-foreground text-xs">
+                    <div className="sk-ui-rounded sk-ui-bg-success sk-ui-px-1 sk-ui-py-0.5 sk-ui-text-success-foreground sk-ui-text-xs">
                       {match(route?.tags)
                         .when(
                           (tags) => tags?.includes(PriorityLabel.RECOMMENDED),
@@ -64,19 +64,19 @@ export const SwapQuoteRouteSelectDialog = ({
                   )}
                 </div>
 
-                <div className="flex items-center gap-1 text-muted-foreground text-xs">
-                  <TimerIcon className="size-4" />
+                <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-1 sk-ui-text-muted-foreground sk-ui-text-xs">
+                  <TimerIcon className="sk-ui-size-4" />
 
-                  <div className="mt-0.5 font-normal">{route?.formattedEstimatedTime}</div>
+                  <div className="sk-ui-mt-0.5 sk-ui-font-normal">{route?.formattedEstimatedTime}</div>
                 </div>
               </div>
 
-              <div className="ml-auto flex flex-col items-end gap-1">
-                <span className="font-medium text-base text-foreground">
+              <div className="sk-ui-ml-auto sk-ui-flex sk-ui-flex-col sk-ui-items-end sk-ui-gap-1">
+                <span className="sk-ui-font-medium sk-ui-text-base sk-ui-text-foreground">
                   {route?.expectedBuyAmount?.toFixed(6)} {route?.outputAssetTicker}
                 </span>
 
-                <span className="font-normal text-muted-foreground text-xs">
+                <span className="sk-ui-font-normal sk-ui-text-muted-foreground sk-ui-text-xs">
                   ≈ {route?.formattedOutputAssetPriceUSD}
                 </span>
               </div>

--- a/packages/ui/src/react/components/dialogs/wallet-connect-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/wallet-connect-dialog.tsx
@@ -222,26 +222,26 @@ export function WalletConnectDialog() {
           <DialogTitle>Connect wallet</DialogTitle>
         </DialogHeader>
 
-        <div className="relative">
+        <div className="sk-ui-relative">
           <Input
-            className="h-10 bg-secondary pl-9 placeholer:text-muted-foreground text-base text-foreground"
+            className="sk-ui-h-10 sk-ui-bg-secondary sk-ui-pl-9 placeholer:sk-ui-text-muted-foreground sk-ui-text-base sk-ui-text-foreground"
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search wallet provider"
             value={searchQuery}
           />
 
-          <SearchIcon className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-muted-foreground" />
+          <SearchIcon className="sk-ui--translate-y-1/2 sk-ui-absolute sk-ui-top-1/2 sk-ui-left-3 sk-ui-size-4 sk-ui-text-muted-foreground" />
         </div>
 
-        <div className="-mx-6 -mb-4 flex max-h-[60svh] flex-1 flex-col gap-4 overflow-auto px-6 pb-6">
+        <div className="sk-ui--mx-6 sk-ui--mb-4 sk-ui-flex sk-ui-max-h-[60svh] sk-ui-flex-1 sk-ui-flex-col sk-ui-gap-4 sk-ui-overflow-auto sk-ui-px-6 sk-ui-pb-6">
           {match({ isShowingAllWallets, searchQuery })
             .with({ isShowingAllWallets: true }, { searchQuery: P.string.minLength(2) }, () =>
               filteredWalletGroups?.map(({ groupTitle, wallets }) => {
                 return (
-                  <div className="flex flex-col gap-2" key={`wallet-group-${groupTitle}`}>
-                    <header className="text-muted-foreground text-sm">{groupTitle}</header>
+                  <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2" key={`wallet-group-${groupTitle}`}>
+                    <header className="sk-ui-text-muted-foreground sk-ui-text-sm">{groupTitle}</header>
 
-                    <div className="grid grid-cols-4 gap-2">
+                    <div className="sk-ui-grid sk-ui-grid-cols-4 sk-ui-gap-2">
                       {wallets?.map((wallet) => (
                         <WalletConnectButton key={`wallet-button-${wallet}`} wallet={wallet} />
                       ))}
@@ -251,7 +251,7 @@ export function WalletConnectDialog() {
               }),
             )
             .otherwise(() => (
-              <div className="grid grid-cols-4 gap-2">
+              <div className="sk-ui-grid sk-ui-grid-cols-4 sk-ui-gap-2">
                 {FEATURED_WALLETS?.map((wallet) => (
                   <WalletConnectButton key={`wallet-button-${wallet}`} wallet={wallet} />
                 ))}
@@ -259,26 +259,26 @@ export function WalletConnectDialog() {
             ))}
         </div>
 
-        <DialogFooter className="items-center justify-center">
+        <DialogFooter className="sk-ui-items-center sk-ui-justify-center">
           <Button
-            className="-mt-1 w-auto text-foreground"
+            className="sk-ui--mt-1 sk-ui-w-auto sk-ui-text-foreground"
             onClick={() => {
               setIsShowingAllWallets((isShowingAllWallets) => !isShowingAllWallets);
             }}
             size="sm"
             variant="ghost">
-            <WalletMinimalIcon className="size-4" />
+            <WalletMinimalIcon className="sk-ui-size-4" />
 
             <span>{isShowingAllWallets ? "Hide all wallets" : "Show all wallets"}</span>
           </Button>
 
-          <p className="max-w-sm text-center text-muted-foreground text-sm">
+          <p className="sk-ui-max-w-sm sk-ui-text-center sk-ui-text-muted-foreground sk-ui-text-sm">
             By connecting your wallet, you agree to our{" "}
-            <a className="text-foreground underline" href="/terms">
+            <a className="sk-ui-text-foreground sk-ui-underline" href="/terms">
               Terms of Service
             </a>{" "}
             and{" "}
-            <a className="text-foreground underline" href="/privacy">
+            <a className="sk-ui-text-foreground sk-ui-underline" href="/privacy">
               Privacy Policy
             </a>
           </p>
@@ -332,13 +332,13 @@ function WalletConnectButton({ wallet }: { wallet: WalletOption }) {
 
   return (
     <Button
-      className="flex aspect-[1.525/1] h-full w-full flex-col items-center justify-center gap-1"
+      className="sk-ui-flex aspect-[1.525/1] sk-ui-h-full sk-ui-w-full sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1"
       isLoading={isConnectingWallet && walletType === wallet}
       key={`wallet-connect-button-${wallet}`}
       onClick={handleWalletClick}>
-      <WalletIcon className="size-5" wallet={wallet} />
+      <WalletIcon className="sk-ui-size-5" wallet={wallet} />
 
-      <span className="text-foreground text-sm">{walletName}</span>
+      <span className="sk-ui-text-foreground sk-ui-text-sm">{walletName}</span>
     </Button>
   );
 }

--- a/packages/ui/src/react/components/dialogs/wallet-connect-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/wallet-connect-dialog.tsx
@@ -259,7 +259,7 @@ export function WalletConnectDialog() {
             ))}
         </div>
 
-        <DialogFooter className="sk-ui-items-center sk-ui-justify-center">
+        <DialogFooter className="sk-ui-items-center sk-ui-justify-center sm:sk-ui-flex-col">
           <Button
             className="sk-ui--mt-1 sk-ui-w-auto sk-ui-text-foreground"
             onClick={() => {
@@ -332,7 +332,7 @@ function WalletConnectButton({ wallet }: { wallet: WalletOption }) {
 
   return (
     <Button
-      className="sk-ui-flex aspect-[1.525/1] sk-ui-h-full sk-ui-w-full sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1"
+      className="sk-ui-flex sk-ui-h-full sk-ui-w-full sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-gap-1 sk-ui-aspect-[1.525/1]"
       isLoading={isConnectingWallet && walletType === wallet}
       key={`wallet-connect-button-${wallet}`}
       onClick={handleWalletClick}>

--- a/packages/ui/src/react/components/dialogs/wallet-keystore-connect-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/wallet-keystore-connect-dialog.tsx
@@ -82,7 +82,8 @@ export function WalletKeystoreConnectDialog() {
           { shouldValidate: true },
         );
       } catch (error) {
-        console.error("Error parsing keystore file:", error); toast.error("Something went wrong while parsing the keystore file", {
+        console.error("Error parsing keystore file:", error);
+        toast.error("Something went wrong while parsing the keystore file", {
           description: "Please check if the file is a valid keystore file",
         });
       }
@@ -102,10 +103,10 @@ export function WalletKeystoreConnectDialog() {
         <Tabs
           onValueChange={(newValue) => form.setValue("currentStep", Number.parseInt(newValue, 10) as 1 | 2 | 3)}
           value={currentStep.toString()}>
-          <TabsList className="sk-ui-h-fit sk-ui-w-full sk-ui-gap-2 sk-ui-bg-transparent sk-ui-p-0">
-            <TabsTrigger className={cn(currentStep > 1 && "sk-ui-bg-accent")} value="1" variant="stepper" />
-            <TabsTrigger className={cn(currentStep > 2 && "sk-ui-bg-accent")} value="2" variant="stepper" />
-            <TabsTrigger className={cn(currentStep >= 3 && "!bg-accent")} value="3" variant="stepper" />
+          <TabsList className="sk-ui-w-full sk-ui-gap-2 sk-ui-h-auto sk-ui-p-0">
+            <TabsTrigger className={cn(currentStep > 1 && "!sk-ui-bg-accent")} value="1" variant="stepper" />
+            <TabsTrigger className={cn(currentStep > 2 && "!sk-ui-bg-accent")} value="2" variant="stepper" />
+            <TabsTrigger className={cn(currentStep >= 3 && "!sk-ui-bg-accent")} value="3" variant="stepper" />
           </TabsList>
 
           <TabsContent value="1">
@@ -121,14 +122,21 @@ export function WalletKeystoreConnectDialog() {
                 <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2">
                   <span className="sk-ui-font-medium sk-ui-text-secondary-hover-text sk-ui-text-sm">Keystore file</span>
                   <label
-                    className={`sk-ui-flex sk-ui-h-24 sk-ui-w-full sk-ui-cursor-pointer sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-rounded-md sk-ui-border-2 sk-ui-border-white sk-ui-border-dashed sk-ui-border-opacity-25 sk-ui-transition-colors hover:sk-ui-border-opacity-40 ${keystoreFile?.file ? "border-green-500 sk-ui-border-opacity-50 bg-green-500/5" : ""} `}
+                    className={cn(
+                      "sk-ui-flex sk-ui-h-24 sk-ui-w-full sk-ui-cursor-pointer sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-rounded-md sk-ui-border-2 sk-ui-border-white sk-ui-border-dashed sk-ui-border-opacity-25 sk-ui-transition-colors hover:sk-ui-border-opacity-40",
+                      keystoreFile?.file && "sk-ui-border-opacity-50 sk-ui-bg-green-500/5 sk-ui-border-green-500",
+                    )}
                     htmlFor={fileInputId}>
                     <div className="sk-ui-flex sk-ui-flex-col sk-ui-items-center sk-ui-gap-2">
                       {keystoreFile?.file ? (
                         <>
                           <CheckIcon className="sk-ui-h-6 sk-ui-w-6 sk-ui-text-green-500" />
-                          <span className="sk-ui-font-medium sk-ui-text-green-400 sk-ui-text-sm">{keystoreFile?.file?.name}</span>
-                          <span className="sk-ui-text-muted-foreground sk-ui-text-xs">Click to select a different file</span>
+                          <span className="sk-ui-font-medium sk-ui-text-green-400 sk-ui-text-sm">
+                            {keystoreFile?.file?.name}
+                          </span>
+                          <span className="sk-ui-text-muted-foreground sk-ui-text-xs">
+                            Click to select a different file
+                          </span>
                         </>
                       ) : (
                         <>
@@ -175,13 +183,17 @@ export function WalletKeystoreConnectDialog() {
           <TabsContent value="2">
             <form onSubmit={handleConnectWallet}>
               <div className="sk-ui-mt-4 sk-ui-flex sk-ui-flex-col sk-ui-gap-4">
-                <span className="sk-ui-text-sm sk-ui-text-white sk-ui-text-opacity-65">Enter the password for your keystore file</span>
+                <span className="sk-ui-text-sm sk-ui-text-white sk-ui-text-opacity-65">
+                  Enter the password for your keystore file
+                </span>
 
                 {keystoreFile?.file && (
                   <div className="sk-ui-rounded-md sk-ui-border sk-ui-border-blue-500/20 sk-ui-bg-blue-500/10 sk-ui-p-3">
                     <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
                       <CheckIcon className="sk-ui-h-4 sk-ui-w-4 sk-ui-text-blue-400" />
-                      <span className="sk-ui-text-blue-300 sk-ui-text-sm">Keystore file: {keystoreFile?.file?.name}</span>
+                      <span className="sk-ui-text-blue-300 sk-ui-text-sm">
+                        Keystore file: {keystoreFile?.file?.name}
+                      </span>
                     </div>
                   </div>
                 )}

--- a/packages/ui/src/react/components/dialogs/wallet-keystore-connect-dialog.tsx
+++ b/packages/ui/src/react/components/dialogs/wallet-keystore-connect-dialog.tsx
@@ -82,8 +82,7 @@ export function WalletKeystoreConnectDialog() {
           { shouldValidate: true },
         );
       } catch (error) {
-        console.error("Error parsing keystore file:", error);
-        toast.error("Something went wrong while parsing the keystore file", {
+        console.error("Error parsing keystore file:", error); toast.error("Something went wrong while parsing the keystore file", {
           description: "Please check if the file is a valid keystore file",
         });
       }
@@ -103,9 +102,9 @@ export function WalletKeystoreConnectDialog() {
         <Tabs
           onValueChange={(newValue) => form.setValue("currentStep", Number.parseInt(newValue, 10) as 1 | 2 | 3)}
           value={currentStep.toString()}>
-          <TabsList className="h-fit w-full gap-2 bg-transparent p-0">
-            <TabsTrigger className={cn(currentStep > 1 && "bg-accent")} value="1" variant="stepper" />
-            <TabsTrigger className={cn(currentStep > 2 && "bg-accent")} value="2" variant="stepper" />
+          <TabsList className="sk-ui-h-fit sk-ui-w-full sk-ui-gap-2 sk-ui-bg-transparent sk-ui-p-0">
+            <TabsTrigger className={cn(currentStep > 1 && "sk-ui-bg-accent")} value="1" variant="stepper" />
+            <TabsTrigger className={cn(currentStep > 2 && "sk-ui-bg-accent")} value="2" variant="stepper" />
             <TabsTrigger className={cn(currentStep >= 3 && "!bg-accent")} value="3" variant="stepper" />
           </TabsList>
 
@@ -114,28 +113,28 @@ export function WalletKeystoreConnectDialog() {
               onSubmit={form.handleSubmit(() => {
                 form.setValue("currentStep", 2);
               })}>
-              <div className="flex flex-col gap-4">
-                <span className="text-sm text-white text-opacity-65">
+              <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-4">
+                <span className="sk-ui-text-sm sk-ui-text-white sk-ui-text-opacity-65">
                   Upload your keystore file to connect your wallet
                 </span>
 
-                <div className="flex flex-col gap-2">
-                  <span className="font-medium text-secondary-hover-text text-sm">Keystore file</span>
+                <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-2">
+                  <span className="sk-ui-font-medium sk-ui-text-secondary-hover-text sk-ui-text-sm">Keystore file</span>
                   <label
-                    className={`flex h-24 w-full cursor-pointer flex-col items-center justify-center rounded-md border-2 border-white border-dashed border-opacity-25 transition-colors hover:border-opacity-40 ${keystoreFile?.file ? "border-green-500 border-opacity-50 bg-green-500/5" : ""} `}
+                    className={`sk-ui-flex sk-ui-h-24 sk-ui-w-full sk-ui-cursor-pointer sk-ui-flex-col sk-ui-items-center sk-ui-justify-center sk-ui-rounded-md sk-ui-border-2 sk-ui-border-white sk-ui-border-dashed sk-ui-border-opacity-25 sk-ui-transition-colors hover:sk-ui-border-opacity-40 ${keystoreFile?.file ? "border-green-500 sk-ui-border-opacity-50 bg-green-500/5" : ""} `}
                     htmlFor={fileInputId}>
-                    <div className="flex flex-col items-center gap-2">
+                    <div className="sk-ui-flex sk-ui-flex-col sk-ui-items-center sk-ui-gap-2">
                       {keystoreFile?.file ? (
                         <>
-                          <CheckIcon className="h-6 w-6 text-green-500" />
-                          <span className="font-medium text-green-400 text-sm">{keystoreFile?.file?.name}</span>
-                          <span className="text-muted-foreground text-xs">Click to select a different file</span>
+                          <CheckIcon className="sk-ui-h-6 sk-ui-w-6 sk-ui-text-green-500" />
+                          <span className="sk-ui-font-medium sk-ui-text-green-400 sk-ui-text-sm">{keystoreFile?.file?.name}</span>
+                          <span className="sk-ui-text-muted-foreground sk-ui-text-xs">Click to select a different file</span>
                         </>
                       ) : (
                         <>
-                          <UploadIcon className="h-6 w-6 text-muted-foreground" />
-                          <span className="font-medium text-sm">Choose keystore file</span>
-                          <span className="text-muted-foreground text-xs">JSON files only</span>
+                          <UploadIcon className="sk-ui-h-6 sk-ui-w-6 sk-ui-text-muted-foreground" />
+                          <span className="sk-ui-font-medium sk-ui-text-sm">Choose keystore file</span>
+                          <span className="sk-ui-text-muted-foreground sk-ui-text-xs">JSON files only</span>
                         </>
                       )}
                     </div>
@@ -143,7 +142,7 @@ export function WalletKeystoreConnectDialog() {
 
                   <input
                     accept=".json,.txt,text/plain,application/json"
-                    className="hidden"
+                    className="sk-ui-hidden"
                     id={fileInputId}
                     onChange={handleKeystoreFileChange}
                     type="file"
@@ -151,13 +150,13 @@ export function WalletKeystoreConnectDialog() {
                 </div>
 
                 {keystoreFile?.file && (
-                  <div className="text-muted-foreground text-xs">
+                  <div className="sk-ui-text-muted-foreground sk-ui-text-xs">
                     Selected: {keystoreFile?.file?.name} ({(keystoreFile?.file?.size / 1024).toFixed(1)} KB)
                   </div>
                 )}
               </div>
 
-              <DialogFooter className="mt-4">
+              <DialogFooter className="sk-ui-mt-4">
                 <Button onClick={() => modal.resolve({ confirmed: false })} type="button">
                   Cancel
                 </Button>
@@ -175,14 +174,14 @@ export function WalletKeystoreConnectDialog() {
 
           <TabsContent value="2">
             <form onSubmit={handleConnectWallet}>
-              <div className="mt-4 flex flex-col gap-4">
-                <span className="text-sm text-white text-opacity-65">Enter the password for your keystore file</span>
+              <div className="sk-ui-mt-4 sk-ui-flex sk-ui-flex-col sk-ui-gap-4">
+                <span className="sk-ui-text-sm sk-ui-text-white sk-ui-text-opacity-65">Enter the password for your keystore file</span>
 
                 {keystoreFile?.file && (
-                  <div className="rounded-md border border-blue-500/20 bg-blue-500/10 p-3">
-                    <div className="flex items-center gap-2">
-                      <CheckIcon className="h-4 w-4 text-blue-400" />
-                      <span className="text-blue-300 text-sm">Keystore file: {keystoreFile?.file?.name}</span>
+                  <div className="sk-ui-rounded-md sk-ui-border sk-ui-border-blue-500/20 sk-ui-bg-blue-500/10 sk-ui-p-3">
+                    <div className="sk-ui-flex sk-ui-items-center sk-ui-gap-2">
+                      <CheckIcon className="sk-ui-h-4 sk-ui-w-4 sk-ui-text-blue-400" />
+                      <span className="sk-ui-text-blue-300 sk-ui-text-sm">Keystore file: {keystoreFile?.file?.name}</span>
                     </div>
                   </div>
                 )}
@@ -212,7 +211,7 @@ export function WalletKeystoreConnectDialog() {
                 </Form>
               </div>
 
-              <DialogFooter className="mt-4">
+              <DialogFooter className="sk-ui-mt-4">
                 <Button onClick={() => form.setValue("currentStep", 1)} type="button">
                   Go Back
                 </Button>
@@ -233,17 +232,17 @@ export function WalletKeystoreConnectDialog() {
               onSubmit={form.handleSubmit(() => {
                 modal.resolve({ confirmed: true, data: undefined });
               })}>
-              <div className="mt-4 flex flex-col gap-4 text-center">
-                <div className="rounded-md border border-green-500/20 bg-green-500/10 p-4">
-                  <CheckIcon className="mx-auto mb-2 h-8 w-8 text-green-500" />
-                  <h3 className="mb-1 font-medium text-green-300">Wallet Connected Successfully!</h3>
-                  <p className="text-muted-foreground text-sm">
+              <div className="sk-ui-mt-4 sk-ui-flex sk-ui-flex-col sk-ui-gap-4 sk-ui-text-center">
+                <div className="sk-ui-rounded-md sk-ui-border sk-ui-border-green-500/20 sk-ui-bg-green-500/10 sk-ui-p-4">
+                  <CheckIcon className="sk-ui-mx-auto sk-ui-mb-2 sk-ui-h-8 sk-ui-w-8 sk-ui-text-green-500" />
+                  <h3 className="sk-ui-mb-1 sk-ui-font-medium sk-ui-text-green-300">Wallet Connected Successfully!</h3>
+                  <p className="sk-ui-text-muted-foreground sk-ui-text-sm">
                     Your keystore wallet is now connected and ready to use.
                   </p>
                 </div>
               </div>
 
-              <DialogFooter className="mt-4">
+              <DialogFooter className="sk-ui-mt-4">
                 <Button onClick={() => form.setValue("currentStep", 2)} type="button">
                   Go Back
                 </Button>

--- a/packages/ui/src/react/components/ui/accordion.tsx
+++ b/packages/ui/src/react/components/ui/accordion.tsx
@@ -18,16 +18,18 @@ const AccordionTrigger = React.forwardRef<
   ComponentRef<typeof AccordionPrimitive.Trigger>,
   ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & { showChevron?: boolean }
 >(({ className, children, showChevron = true, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex">
+  <AccordionPrimitive.Header className="sk-ui-flex">
     <AccordionPrimitive.Trigger
       className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        "sk-ui-flex sk-ui-flex-1 sk-ui-items-center sk-ui-justify-between sk-ui-py-4 sk-ui-font-medium sk-ui-transition-all hover:sk-ui-underline [&[data-state=open]>svg]:sk-ui-rotate-180",
         className,
       )}
       ref={ref}
       {...props}>
       {children}
-      {showChevron && <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />}
+      {showChevron && (
+        <ChevronDown className="sk-ui-h-4 sk-ui-w-4 sk-ui-shrink-0 sk-ui-transition-transform sk-ui-duration-200" />
+      )}
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));
@@ -38,10 +40,10 @@ const AccordionContent = React.forwardRef<
   ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="sk-ui-overflow-hidden sk-ui-text-sm sk-ui-transition-all data-[state=closed]:sk-ui-animate-accordion-up data-[state=open]:sk-ui-animate-accordion-down"
     ref={ref}
     {...props}>
-    <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    <div className={cn("sk-ui-pt-0 sk-ui-pb-4", className)}>{children}</div>
   </AccordionPrimitive.Content>
 ));
 

--- a/packages/ui/src/react/components/ui/button.tsx
+++ b/packages/ui/src/react/components/ui/button.tsx
@@ -7,32 +7,32 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50",
+  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-md sk-ui-text-sm sk-ui-font-medium sk-ui-ring-offset-background sk-ui-transition-colors sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-0 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50",
   {
     defaultVariants: { size: "default", variant: "default" },
     variants: {
       // biome-ignore assist/source/useSortedKeys: sort by size, not alphabetically
       size: {
-        sm: "h-9 rounded-md px-3 gap-1.5",
-        default: "h-10 px-4 py-2 gap-2",
-        lg: "h-12 font-medium text-base rounded-lg px-4",
-        xl: "h-11 font-medium text-base rounded-xl px-8",
-        icon: "size-10",
-        unstyled: "p-0 m-0 h-auto w-auto",
+        sm: "sk-ui-h-9 sk-ui-rounded-md sk-ui-px-3 sk-ui-gap-1.5",
+        default: "sk-ui-h-10 sk-ui-px-4 sk-ui-py-2 sk-ui-gap-2",
+        lg: "sk-ui-h-12 sk-ui-font-medium sk-ui-text-base sk-ui-rounded-lg sk-ui-px-4",
+        xl: "sk-ui-h-11 sk-ui-font-medium sk-ui-text-base sk-ui-rounded-xl sk-ui-px-8",
+        icon: "sk-ui-size-10",
+        unstyled: "sk-ui-p-0 sk-ui-m-0 sk-ui-h-auto sk-ui-w-auto",
       },
       // biome-ignore assist/source/useSortedKeys: sort by role, not alphabetically
       variant: {
-        default: "bg-white/[0.08] text-muted-foreground  hover:bg-white/[0.12]",
-        ghost: "hover:bg-white/[0.08] bg-transparent hover:text-foreground text-muted-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        default: "sk-ui-bg-white/[0.08] sk-ui-text-muted-foreground hover:sk-ui-bg-white/[0.12]",
+        ghost: "hover:sk-ui-bg-white/[0.08] sk-ui-bg-transparent hover:sk-ui-text-foreground sk-ui-text-muted-foreground",
+        link: "sk-ui-text-primary sk-ui-underline-offset-4 hover:sk-ui-underline",
+        outline: "sk-ui-border sk-ui-border-input sk-ui-bg-background hover:sk-ui-bg-accent hover:sk-ui-text-accent-foreground",
 
-        primary: "bg-primary-foreground text-primary hover:opacity-80 transition-opacity",
-        secondary: "bg-secondary text-secondary-foreground hover:opacity-80 transition-opacity",
-        tertiary: "bg-tertiary text-tertiary-foreground hover:opacity-80 transition-opacity",
+        primary: "sk-ui-bg-primary-foreground sk-ui-text-primary hover:sk-ui-opacity-80 sk-ui-transition-opacity",
+        secondary: "sk-ui-bg-secondary sk-ui-text-secondary-foreground hover:sk-ui-opacity-80 sk-ui-transition-opacity",
+        tertiary: "sk-ui-bg-tertiary sk-ui-text-tertiary-foreground hover:sk-ui-opacity-80 sk-ui-transition-opacity",
 
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        unstyled: "p-0 m-0 h-auto w-auto",
+        destructive: "sk-ui-bg-destructive sk-ui-text-destructive-foreground hover:sk-ui-bg-destructive/90",
+        unstyled: "sk-ui-p-0 sk-ui-m-0 sk-ui-h-auto sk-ui-w-auto",
       },
     },
   },
@@ -51,12 +51,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Comp className={cn(buttonVariants({ className, size, variant }))} ref={ref} {...props}>
         {isLoading ? (
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Loader2Icon className="size-5 animate-spin" />
+          <div className="sk-ui-relative">
+            <div className="sk-ui-absolute sk-ui-inset-0 sk-ui-flex sk-ui-items-center sk-ui-justify-center">
+              <Loader2Icon className="sk-ui-size-5 sk-ui-animate-spin" />
             </div>
 
-            <div className="invisible">
+            <div className="sk-ui-invisible">
               <Slottable>{children}</Slottable>
             </div>
           </div>

--- a/packages/ui/src/react/components/ui/button.tsx
+++ b/packages/ui/src/react/components/ui/button.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 
 const buttonVariants = cva(
-  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-md sk-ui-text-sm sk-ui-font-medium sk-ui-ring-offset-background sk-ui-transition-colors sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-0 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50",
+  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-md sk-ui-text-sm sk-ui-font-medium sk-ui-ring-offset-background sk-ui-transition-colors focus-visible:outline-none focus-visible:sk-ui-ring-2 focus-visible:sk-ui-ring-ring focus-visible:ring-offset-0 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50",
   {
     defaultVariants: { size: "default", variant: "default" },
     variants: {
@@ -23,9 +23,11 @@ const buttonVariants = cva(
       // biome-ignore assist/source/useSortedKeys: sort by role, not alphabetically
       variant: {
         default: "sk-ui-bg-white/[0.08] sk-ui-text-muted-foreground hover:sk-ui-bg-white/[0.12]",
-        ghost: "hover:sk-ui-bg-white/[0.08] sk-ui-bg-transparent hover:sk-ui-text-foreground sk-ui-text-muted-foreground",
+        ghost:
+          "hover:sk-ui-bg-white/[0.08] sk-ui-bg-transparent hover:sk-ui-text-foreground sk-ui-text-muted-foreground",
         link: "sk-ui-text-primary sk-ui-underline-offset-4 hover:sk-ui-underline",
-        outline: "sk-ui-border sk-ui-border-input sk-ui-bg-background hover:sk-ui-bg-accent hover:sk-ui-text-accent-foreground",
+        outline:
+          "sk-ui-border sk-ui-border-input sk-ui-bg-background hover:sk-ui-bg-accent hover:sk-ui-text-accent-foreground",
 
         primary: "sk-ui-bg-primary-foreground sk-ui-text-primary hover:sk-ui-opacity-80 sk-ui-transition-opacity",
         secondary: "sk-ui-bg-secondary sk-ui-text-secondary-foreground hover:sk-ui-opacity-80 sk-ui-transition-opacity",

--- a/packages/ui/src/react/components/ui/card.tsx
+++ b/packages/ui/src/react/components/ui/card.tsx
@@ -5,36 +5,36 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div className={cn("rounded-xl bg-card text-card-foreground shadow-sm", className)} ref={ref} {...props} />
+  <div className={cn("sk-ui-rounded-xl sk-ui-bg-card sk-ui-text-card-foreground sk-ui-shadow-sm", className)} ref={ref} {...props} />
 ));
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div className={cn("flex flex-col space-y-1.5", className)} ref={ref} {...props} />,
+  ({ className, ...props }, ref) => <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-space-y-1.5", className)} ref={ref} {...props} />,
 );
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 className={cn("font-semibold text-2xl leading-none tracking-tight", className)} ref={ref} {...props} />
+    <h3 className={cn("sk-ui-font-semibold sk-ui-text-2xl sk-ui-leading-none sk-ui-tracking-tight", className)} ref={ref} {...props} />
   ),
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
   ({ className, ...props }, ref) => (
-    <p className={cn("text-muted-foreground text-sm", className)} ref={ref} {...props} />
+    <p className={cn("sk-ui-text-muted-foreground sk-ui-text-sm", className)} ref={ref} {...props} />
   ),
 );
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div className={cn("p-4", className)} ref={ref} {...props} />,
+  ({ className, ...props }, ref) => <div className={cn("sk-ui-p-4", className)} ref={ref} {...props} />,
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div className={cn("flex items-center px-4", className)} ref={ref} {...props} />,
+  ({ className, ...props }, ref) => <div className={cn("sk-ui-flex sk-ui-items-center sk-ui-px-4", className)} ref={ref} {...props} />,
 );
 CardFooter.displayName = "CardFooter";
 

--- a/packages/ui/src/react/components/ui/dialog.tsx
+++ b/packages/ui/src/react/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "data-[state=closed]:sk-ui-fade-out-0 data-[state=open]:sk-ui-fade-in-0 sk-ui-fixed sk-ui-inset-0 sk-ui-z-50 sk-ui-bg-black/80 data-[state=closed]:sk-ui-animate-out data-[state=open]:sk-ui-animate-in",
       className,
     )}
     ref={ref}
@@ -37,15 +37,15 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid max-h-[90svh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-secondary p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg",
+        "data-[state=closed]:sk-ui-fade-out-0 data-[state=open]:sk-ui-fade-in-0 data-[state=closed]:sk-ui-zoom-out-95 data-[state=open]:sk-ui-zoom-in-95 data-[state=closed]:sk-ui-slide-out-to-left-1/2 data-[state=closed]:sk-ui-slide-out-to-top-[48%] data-[state=open]:sk-ui-slide-in-from-left-1/2 data-[state=open]:sk-ui-slide-in-from-top-[48%] sk-ui-fixed sk-ui-top-[50%] sk-ui-left-[50%] sk-ui-z-50 sk-ui-grid sk-ui-max-h-[90svh] sk-ui-w-full sk-ui-max-w-lg sk-ui-translate-x-[-50%] sk-ui-translate-y-[-50%] sk-ui-gap-4 sk-ui-border sk-ui-bg-secondary sk-ui-p-6 sk-ui-shadow-lg sk-ui-duration-200 data-[state=closed]:sk-ui-animate-out data-[state=open]:sk-ui-animate-in sm:sk-ui-rounded-lg",
         className,
       )}
       ref={ref}
       {...props}>
       {children}
-      <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="size-4" />
-        <span className="sr-only">Close</span>
+      <DialogPrimitive.Close className="sk-ui-absolute sk-ui-top-4 sk-ui-right-4 sk-ui-rounded-sm sk-ui-opacity-70 sk-ui-ring-offset-background sk-ui-transition-opacity hover:sk-ui-opacity-100 focus:sk-ui-outline-none focus:sk-ui-ring-2 focus:sk-ui-ring-ring focus:sk-ui-ring-offset-2 disabled:sk-ui-pointer-events-none data-[state=open]:sk-ui-bg-accent data-[state=open]:sk-ui-text-muted-foreground">
+        <X className="sk-ui-size-4" />
+        <span className="sk-ui-sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
@@ -53,13 +53,13 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+  <div className={cn("sk-ui-flex sk-ui-flex-col sk-ui-space-y-1.5 sk-ui-text-center sm:sk-ui-text-left", className)} {...props} />
 );
 DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("-mx-6 -mb-6 flex w-auto flex-col justify-between border-t px-6 py-2 sm:flex-row", className)}
+    className={cn("sk-ui--mx-6 sk-ui--mb-6 sk-ui-flex sk-ui-w-auto sk-ui-flex-col sk-ui-justify-between sk-ui-border-t sk-ui-px-6 sk-ui-py-2 sm:sk-ui-flex-row", className)}
     {...props}
   />
 );
@@ -70,7 +70,7 @@ const DialogTitle = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
-    className={cn("font-medium text-xl leading-none tracking-tight", className)}
+    className={cn("sk-ui-font-medium sk-ui-text-xl sk-ui-leading-none sk-ui-tracking-tight", className)}
     ref={ref}
     {...props}
   />
@@ -81,7 +81,7 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description className={cn("text-muted-foreground text-sm", className)} ref={ref} {...props} />
+  <DialogPrimitive.Description className={cn("sk-ui-text-muted-foreground sk-ui-text-sm", className)} ref={ref} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 

--- a/packages/ui/src/react/components/ui/form.tsx
+++ b/packages/ui/src/react/components/ui/form.tsx
@@ -74,7 +74,7 @@ const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
 
     return (
       <FormItemContext.Provider value={{ id }}>
-        <div className={cn("space-y-2", className)} ref={ref} {...props} />
+        <div className={cn("sk-ui-space-y-2", className)} ref={ref} {...props} />
       </FormItemContext.Provider>
     );
   },
@@ -87,7 +87,7 @@ const FormLabel = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const { error, formItemId } = useFormField();
 
-  return <Label className={cn(error && "text-destructive", className)} htmlFor={formItemId} ref={ref} {...props} />;
+  return <Label className={cn(error && "sk-ui-text-destructive", className)} htmlFor={formItemId} ref={ref} {...props} />;
 });
 FormLabel.displayName = "FormLabel";
 
@@ -112,7 +112,7 @@ const FormDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttribu
   ({ className, ...props }, ref) => {
     const { formDescriptionId } = useFormField();
 
-    return <p className={cn("text-muted-foreground text-sm", className)} id={formDescriptionId} ref={ref} {...props} />;
+    return <p className={cn("sk-ui-text-muted-foreground sk-ui-text-sm", className)} id={formDescriptionId} ref={ref} {...props} />;
   },
 );
 FormDescription.displayName = "FormDescription";
@@ -127,7 +127,7 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
     }
 
     return (
-      <p className={cn("font-medium text-destructive text-sm", className)} id={formMessageId} ref={ref} {...props}>
+      <p className={cn("sk-ui-font-medium sk-ui-text-destructive sk-ui-text-sm", className)} id={formMessageId} ref={ref} {...props}>
         {body}
       </p>
     );

--- a/packages/ui/src/react/components/ui/input.tsx
+++ b/packages/ui/src/react/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
   return (
     <input
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "sk-ui-flex sk-ui-h-10 sk-ui-w-full sk-ui-rounded-md sk-ui-border sk-ui-border-input sk-ui-bg-background sk-ui-px-3 sk-ui-py-2 sk-ui-text-sm sk-ui-ring-offset-background file:sk-ui-border-0 file:sk-ui-bg-transparent file:sk-ui-font-medium file:sk-ui-text-sm placeholder:sk-ui-text-muted-foreground sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2 disabled:sk-ui-cursor-not-allowed disabled:sk-ui-opacity-50",
         className,
       )}
       ref={ref}

--- a/packages/ui/src/react/components/ui/input.tsx
+++ b/packages/ui/src/react/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
   return (
     <input
       className={cn(
-        "sk-ui-flex sk-ui-h-10 sk-ui-w-full sk-ui-rounded-md sk-ui-border sk-ui-border-input sk-ui-bg-background sk-ui-px-3 sk-ui-py-2 sk-ui-text-sm sk-ui-ring-offset-background file:sk-ui-border-0 file:sk-ui-bg-transparent file:sk-ui-font-medium file:sk-ui-text-sm placeholder:sk-ui-text-muted-foreground sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2 disabled:sk-ui-cursor-not-allowed disabled:sk-ui-opacity-50",
+        "sk-ui-flex sk-ui-h-10 sk-ui-w-full sk-ui-rounded-md sk-ui-border sk-ui-border-input sk-ui-bg-background sk-ui-px-3 sk-ui-py-2 sk-ui-text-sm sk-ui-ring-offset-background file:sk-ui-border-0 file:sk-ui-bg-transparent file:sk-ui-font-medium file:sk-ui-text-sm placeholder:sk-ui-text-muted-foreground disabled:sk-ui-cursor-not-allowed disabled:sk-ui-opacity-50 focus-visible:sk-ui-ring-2 focus-visible:sk-ui-ring-ring focus-visible:sk-ui-ring-offset-2 focus-visible:sk-ui-outline-none",
         className,
       )}
       ref={ref}

--- a/packages/ui/src/react/components/ui/label.tsx
+++ b/packages/ui/src/react/components/ui/label.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 
 import { cn } from "../../../lib/utils";
 
-const labelVariants = cva("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
+const labelVariants = cva("sk-ui-text-sm sk-ui-font-medium sk-ui-leading-none sk-ui-peer-disabled:cursor-not-allowed sk-ui-peer-disabled:opacity-70");
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,

--- a/packages/ui/src/react/components/ui/tabs.tsx
+++ b/packages/ui/src/react/components/ui/tabs.tsx
@@ -6,10 +6,14 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 
 const tabsTriggerVariants = cva(
-  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-sm sk-ui-px-3 sk-ui-py-1.5 sk-ui-font-medium sk-ui-text-sm sk-ui-ring-offset-background sk-ui-transition-all sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50 data-[state=active]:sk-ui-bg-accent data-[state=active]:sk-ui-text-foreground data-[state=active]:sk-ui-shadow-sm",
+  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-sm sk-ui-px-3 sk-ui-py-1.5 sk-ui-font-medium sk-ui-text-sm sk-ui-ring-offset-background sk-ui-transition-all focus-visible:sk-ui-outline-none focus-visible:sk-ui-ring-2 focus-visible:sk-ui-ring-ring focus-visible:sk-ui-ring-offset-2 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50 data-[state=active]:sk-ui-bg-accent data-[state=active]:sk-ui-text-foreground data-[state=active]:sk-ui-shadow-sm",
   {
     defaultVariants: { variant: "stepper" },
-    variants: { variant: { stepper: "sk-ui-h-1 sk-ui-flex-auto sk-ui-bg-white/[0.16] sk-ui-p-0 data-[state=active]:sk-ui-bg-accent" } },
+    variants: {
+      variant: {
+        stepper: "!sk-ui-h-1 sk-ui-flex-auto sk-ui-bg-white/[0.16] !sk-ui-p-0 data-[state=active]:sk-ui-bg-accent",
+      },
+    },
   },
 );
 
@@ -21,7 +25,7 @@ const TabsList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     className={cn(
-      "sk-ui-inline-flex sk-ui-h-8 sk-ui-items-center sk-ui-justify-center sk-ui-gap-0.5 sk-ui-rounded-md sk-ui-bg-white-8 sk-ui-px-0.5 sk-ui-text-white-92",
+      "sk-ui-inline-flex sk-ui-h-8 sk-ui-items-center sk-ui-justify-center sk-ui-gap-0.5 sk-ui-rounded-md sk-ui-px-0.5 sk-ui-text-white/[0.92]",
       className,
     )}
     ref={ref}
@@ -34,7 +38,7 @@ const TabsTrigger = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & VariantProps<typeof tabsTriggerVariants>
 >(({ className, variant, ...props }, ref) => (
-  <TabsPrimitive.Trigger className={cn(tabsTriggerVariants({ className, variant }))} ref={ref} {...props} />
+  <TabsPrimitive.Trigger className={cn(tabsTriggerVariants({ variant }), className)} ref={ref} {...props} />
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
@@ -44,7 +48,7 @@ const TabsContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     className={cn(
-      "sk-ui-mt-2 sk-ui-ring-offset-background sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2",
+      "sk-ui-mt-2 sk-ui-ring-offset-background focus-visible:sk-ui-ring-2 focus-visible:sk-ui-ring-ring focus-visible:sk-ui-outline-none focus-visible:sk-ui-ring-offset-2",
       className,
     )}
     ref={ref}

--- a/packages/ui/src/react/components/ui/tabs.tsx
+++ b/packages/ui/src/react/components/ui/tabs.tsx
@@ -6,10 +6,10 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 
 const tabsTriggerVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 font-medium text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+  "sk-ui-inline-flex sk-ui-items-center sk-ui-justify-center sk-ui-whitespace-nowrap sk-ui-rounded-sm sk-ui-px-3 sk-ui-py-1.5 sk-ui-font-medium sk-ui-text-sm sk-ui-ring-offset-background sk-ui-transition-all sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2 disabled:sk-ui-pointer-events-none disabled:sk-ui-opacity-50 data-[state=active]:sk-ui-bg-accent data-[state=active]:sk-ui-text-foreground data-[state=active]:sk-ui-shadow-sm",
   {
     defaultVariants: { variant: "stepper" },
-    variants: { variant: { stepper: "h-1 flex-auto bg-white/[0.16] p-0 data-[state=active]:bg-accent" } },
+    variants: { variant: { stepper: "sk-ui-h-1 sk-ui-flex-auto sk-ui-bg-white/[0.16] sk-ui-p-0 data-[state=active]:sk-ui-bg-accent" } },
   },
 );
 
@@ -21,7 +21,7 @@ const TabsList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     className={cn(
-      "inline-flex h-8 items-center justify-center gap-0.5 rounded-md bg-white-8 px-0.5 text-white-92",
+      "sk-ui-inline-flex sk-ui-h-8 sk-ui-items-center sk-ui-justify-center sk-ui-gap-0.5 sk-ui-rounded-md sk-ui-bg-white-8 sk-ui-px-0.5 sk-ui-text-white-92",
       className,
     )}
     ref={ref}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "sk-ui-mt-2 sk-ui-ring-offset-background sk-ui-focus-visible:outline-none sk-ui-focus-visible:ring-2 sk-ui-focus-visible:ring-ring sk-ui-focus-visible:ring-offset-2",
       className,
     )}
     ref={ref}

--- a/packages/ui/src/react/components/wallet-icon.tsx
+++ b/packages/ui/src/react/components/wallet-icon.tsx
@@ -8,7 +8,7 @@ export function WalletIcon({ wallet, className = "" }: { wallet: WalletOption; c
   return (
     <img
       alt={wallet}
-      className={cn("inline-block size-5 object-contain", className)}
+      className={cn("sk-ui-inline-block sk-ui-size-5 sk-ui-object-contain", className)}
       src={`${temp_host}/images/wallets/${wallet.toLowerCase()}.png`}
     />
   );

--- a/packages/ui/src/react/swapkit-context.tsx
+++ b/packages/ui/src/react/swapkit-context.tsx
@@ -192,8 +192,7 @@ export const useSwapKit = () => {
 
         await Promise.allSettled(keystoreFile.chains.map((balance) => swapKit?.getWalletWithBalance(balance)));
       } catch (error) {
-        console.error("Failed to decrypt keystore:", error);
-        throw new Error("Failed to decrypt keystore");
+        console.error("Failed to decrypt keystore:", error); throw new Error("Failed to decrypt keystore");
       } finally {
         setIsConnectingWallet(false);
       }

--- a/packages/ui/src/react/swapkit-widget.tsx
+++ b/packages/ui/src/react/swapkit-widget.tsx
@@ -122,7 +122,7 @@ export function SwapKitWidget({ config }: SwapKitWidgetProps) {
   const submitButtonContent = match({ amount, inputAsset, isSwapping, isWalletConnected, outputAsset })
     .with({ isSwapping: true }, () => (
       <>
-        <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+        <Loader2Icon className="sk-ui-mr-2 sk-ui-h-4 sk-ui-w-4 sk-ui-animate-spin" />
         Swapping...
       </>
     ))
@@ -137,13 +137,13 @@ export function SwapKitWidget({ config }: SwapKitWidgetProps) {
     isFetchingQuote;
 
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="font-medium text-2xl">Swap</h1>
+    <div className="sk-ui-flex sk-ui-flex-col sk-ui-gap-4">
+      <h1 className="sk-ui-font-medium sk-ui-text-2xl">Swap</h1>
 
       <Card>
-        <CardContent className="grid gap-6">
-          <div className="space-y-4">
-            <div className="grid gap-4">
+        <CardContent className="sk-ui-grid sk-ui-gap-6">
+          <div className="sk-ui-space-y-4">
+            <div className="sk-ui-grid sk-ui-gap-4">
               <SwapInputWithChainSelector
                 amount={amount}
                 formattedAmountUSD={selectedRoute?.formattedInputAssetPriceUSD}
@@ -154,11 +154,11 @@ export function SwapKitWidget({ config }: SwapKitWidgetProps) {
                 setSelectedAsset={setInputAsset}
               />
 
-              <div className="-my-4 flex items-center space-x-4">
-                <span className="h-px w-full bg-border" />
+              <div className="sk-ui--my-4 sk-ui-flex sk-ui-items-center sk-ui-space-x-4">
+                <span className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
 
                 <Button
-                  className="size-10 shrink-0 rounded-full"
+                  className="sk-ui-size-10 sk-ui-shrink-0 sk-ui-rounded-full"
                   onClick={() => {
                     setInputAsset(outputAsset);
                     setOutputAsset(inputAsset);
@@ -167,10 +167,10 @@ export function SwapKitWidget({ config }: SwapKitWidgetProps) {
                   }}
                   size="unstyled"
                   variant="tertiary">
-                  <ArrowDownUpIcon className="size-6" />
+                  <ArrowDownUpIcon className="sk-ui-size-6" />
                 </Button>
 
-                <span className="h-px w-full bg-border" />
+                <span className="sk-ui-h-px sk-ui-w-full sk-ui-bg-border" />
               </div>
 
               <SwapInputWithChainSelector
@@ -188,7 +188,7 @@ export function SwapKitWidget({ config }: SwapKitWidgetProps) {
       </Card>
 
       <Button
-        className="w-full"
+        className="sk-ui-w-full"
         disabled={isSubmitButtonDisabled}
         onClick={handleSubmitButtonClick}
         size="xl"

--- a/packages/ui/src/swapkit.css
+++ b/packages/ui/src/swapkit.css
@@ -34,6 +34,9 @@
     --sk-ui-destructive: 0 62.8% 30.6%;
     --sk-ui-destructive-foreground: 60 9.1% 97.8%;
 
+    --sk-ui-success: 160 69% 45% / 0.16;
+    --sk-ui-success-foreground: 160 69% 45%;
+
     --sk-ui-border: var(--sk-ui-white) / 0.12;
     --sk-ui-input: var(--sk-ui-white) / 0.32;
     --sk-ui-ring: 24 5.7% 82.9%;

--- a/packages/ui/src/swapkit.css
+++ b/packages/ui/src/swapkit.css
@@ -4,46 +4,46 @@
 
 @layer base {
   :root {
-    --white: 0 0% 100%;
-    --black: 0 0% 0%;
+    --sk-ui-white: 0 0% 100%;
+    --sk-ui-black: 0 0% 0%;
 
-    --background: var(--primary);
-    --foreground: var(--primary-foreground);
+    --sk-ui-background: var(--primary);
+    --sk-ui-foreground: var(--primary-foreground);
 
-    --card: var(--secondary);
-    --card-foreground: var(--secondary-foreground);
+    --sk-ui-card: var(--secondary);
+    --sk-ui-card-foreground: var(--secondary-foreground);
 
-    --popover: 20 14.3% 4.1%;
-    --popover-foreground: 60 9.1% 97.8%;
+    --sk-ui-popover: 20 14.3% 4.1%;
+    --sk-ui-popover-foreground: 60 9.1% 97.8%;
 
-    --primary: 140 6% 8%;
-    --primary-foreground: var(--white) / 92%;
+    --sk-ui-primary: 140 6% 8%;
+    --sk-ui-primary-foreground: var(--sk-ui-white) / 92%;
 
-    --secondary: 120 3% 13%;
-    --secondary-foreground: var(--white) / 0.92;
+    --sk-ui-secondary: 120 3% 13%;
+    --sk-ui-secondary-foreground: var(--sk-ui-white) / 0.92;
 
-    --tertiary: var(--white) / 0.92;
-    --tertiary-foreground: 120 3% 13%;
+    --sk-ui-tertiary: var(--sk-ui-white) / 0.92;
+    --sk-ui-tertiary-foreground: 120 3% 13%;
 
-    --muted: var(--secondary);
-    --muted-foreground: var(--white) / 0.64;
+    --sk-ui-muted: var(--sk-ui-secondary);
+    --sk-ui-muted-foreground: var(--sk-ui-white) / 0.64;
 
-    --accent: 140 87% 79%;
-    --accent-foreground: 60 9.1% 97.8%;
+    --sk-ui-accent: 140 87% 79%;
+    --sk-ui-accent-foreground: 60 9.1% 97.8%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 60 9.1% 97.8%;
+    --sk-ui-destructive: 0 62.8% 30.6%;
+    --sk-ui-destructive-foreground: 60 9.1% 97.8%;
 
-    --border: var(--white) / 0.12;
-    --input: var(--white) / 0.32;
-    --ring: 24 5.7% 82.9%;
+    --sk-ui-border: var(--sk-ui-white) / 0.12;
+    --sk-ui-input: var(--sk-ui-white) / 0.32;
+    --sk-ui-ring: 24 5.7% 82.9%;
   }
 
   * {
-    @apply border-border antialiased;
+    @apply sk-ui-border-border sk-ui-antialiased;
   }
   
   body {
-    @apply bg-background text-foreground;
+    @apply sk-ui-bg-background sk-ui-text-foreground;
   }
 }

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,9 +1,12 @@
 import type { Config } from "tailwindcss";
 
+import tailwindCssAnimatePlugin from "tailwindcss-animate";
+
 const config = {
   content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  corePlugins: { preflight: false },
   darkMode: "class",
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindCssAnimatePlugin],
   prefix: "sk-ui-",
   theme: {
     container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
@@ -11,25 +14,28 @@ const config = {
       animation: { "accordion-down": "accordion-down 0.2s ease-out", "accordion-up": "accordion-up 0.2s ease-out" },
       // biome-ignore assist/source/useSortedKeys: sort by use case, not alphabetically
       colors: {
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        background: "hsl(var(--sk-ui-background))",
+        foreground: "hsl(var(--sk-ui-foreground))",
 
-        primary: { DEFAULT: "hsl(var(--primary))", foreground: "hsl(var(--primary-foreground))" },
-        secondary: { DEFAULT: "hsl(var(--secondary))", foreground: "hsl(var(--secondary-foreground))" },
-        tertiary: { DEFAULT: "hsl(var(--tertiary))", foreground: "hsl(var(--tertiary-foreground))" },
+        primary: { DEFAULT: "hsl(var(--sk-ui-primary))", foreground: "hsl(var(--sk-ui-primary-foreground))" },
+        secondary: { DEFAULT: "hsl(var(--sk-ui-secondary))", foreground: "hsl(var(--sk-ui-secondary-foreground))" },
+        tertiary: { DEFAULT: "hsl(var(--sk-ui-tertiary))", foreground: "hsl(var(--sk-ui-tertiary-foreground))" },
 
-        accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
-        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
+        accent: { DEFAULT: "hsl(var(--sk-ui-accent))", foreground: "hsl(var(--sk-ui-accent-foreground))" },
+        muted: { DEFAULT: "hsl(var(--sk-ui-muted))", foreground: "hsl(var(--sk-ui-muted-foreground))" },
 
-        destructive: { DEFAULT: "hsl(var(--destructive))", foreground: "hsl(var(--destructive-foreground))" },
-        success: { DEFAULT: "hsl(var(--success))", foreground: "hsl(var(--success-foreground))" },
+        destructive: {
+          DEFAULT: "hsl(var(--sk-ui-destructive))",
+          foreground: "hsl(var(--sk-ui-destructive-foreground))",
+        },
+        success: { DEFAULT: "hsl(var(--sk-ui-success))", foreground: "hsl(var(--sk-ui-success-foreground))" },
 
-        border: "hsl(var(--border))",
-        ring: "hsl(var(--ring))",
-        input: "hsl(var(--input))",
+        border: "hsl(var(--sk-ui-border))",
+        ring: "hsl(var(--sk-ui-ring))",
+        input: "hsl(var(--sk-ui-input))",
 
-        card: { DEFAULT: "hsl(var(--card))", foreground: "hsl(var(--card-foreground))" },
-        popover: { DEFAULT: "hsl(var(--popover))", foreground: "hsl(var(--popover-foreground))" },
+        card: { DEFAULT: "hsl(var(--sk-ui-card))", foreground: "hsl(var(--sk-ui-card-foreground))" },
+        popover: { DEFAULT: "hsl(var(--sk-ui-popover))", foreground: "hsl(var(--sk-ui       -popover-foreground))" },
       },
       keyframes: {
         "accordion-down": { from: { height: "0" }, to: { height: "var(--radix-accordion-content-height)" } },

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -4,7 +4,7 @@ const config = {
   content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   darkMode: "class",
   plugins: [require("tailwindcss-animate")],
-  prefix: "",
+  prefix: "sk-ui-",
   theme: {
     container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
     extend: {

--- a/playgrounds/bun-react/package.json
+++ b/playgrounds/bun-react/package.json
@@ -12,7 +12,7 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-hook-form": "7.65.0",
-    "tailwind-merge": "3.3.1",
+    "tailwind-merge": "2.6.0",
     "tailwindcss": "3.4.18",
     "tailwindcss-animate": "1.0.7",
     "zod": "3.25.74"

--- a/playgrounds/nextjs/package.json
+++ b/playgrounds/nextjs/package.json
@@ -49,7 +49,7 @@
     "sonner": "2.0.7",
     "stream-browserify": "3.0.0",
     "stream-http": "3.2.0",
-    "tailwind-merge": "3.3.1",
+    "tailwind-merge": "2.6.0",
     "tailwindcss-animate": "1.0.7",
     "ts-pattern": "5.9.0",
     "url": "0.11.4",

--- a/playgrounds/nextjs/src/app/globals.css
+++ b/playgrounds/nextjs/src/app/globals.css
@@ -34,9 +34,6 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 60 9.1% 97.8%;
 
-    --success: 160 69% 45% / 0.16;
-    --success-foreground: 160 69% 45%;
-
     --border: var(--white) / 0.12;
     --input: 12 6.5% 15.1%;
     --ring: 24 5.7% 82.9%;


### PR DESCRIPTION
### Done:
- [x] add `sk-ui-` prefix to prevent className conflicts
- [x] downgrade `tailwind-merge` to work with tailwindcss v3
- [x] configure `twMerge` to work properly with the new prefix
- [x] update components throughout `@swapkit/ui` to use new prefixed classNames