### PR TITLE
Fix EVM signMessage loosing context

### DIFF
--- a/.changeset/legal-guests-own.md
+++ b/.changeset/legal-guests-own.md
@@ -1,0 +1,5 @@
+---
+"@swapkit/toolboxes": patch
+---
+
+Fix evm signMessage method loosing context

--- a/packages/toolboxes/src/evm/__tests__/signMessage.test.ts
+++ b/packages/toolboxes/src/evm/__tests__/signMessage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { Chain } from "@swapkit/helpers";
+import { getEvmToolbox } from "../toolbox";
+
+const TEST_PHRASE = "test test test test test test test test test test test junk";
+const TEST_MESSAGE = "Hello, this is a test message for SIWE";
+const EXPECTED_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+describe("EVM signMessage", () => {
+  test("should sign message with phrase-based signer", async () => {
+    const toolbox = await getEvmToolbox(Chain.Ethereum, { phrase: TEST_PHRASE });
+
+    const address = await toolbox.getAddress();
+    expect(address).toBe(EXPECTED_ADDRESS);
+
+    const signature = await toolbox.signMessage?.(TEST_MESSAGE);
+
+    expect(signature).toBeDefined();
+    expect(typeof signature).toBe("string");
+  });
+
+  test("should sign Uint8Array message with phrase-based signer", async () => {
+    const toolbox = await getEvmToolbox(Chain.Ethereum, { phrase: TEST_PHRASE });
+
+    const messageBytes = new TextEncoder().encode(TEST_MESSAGE);
+    const signature = await toolbox.signMessage?.(messageBytes);
+
+    expect(signature).toBeDefined();
+    expect(typeof signature).toBe("string");
+  });
+
+  test("should produce consistent signatures for same message", async () => {
+    const toolbox = await getEvmToolbox(Chain.Ethereum, { phrase: TEST_PHRASE });
+
+    const signature1 = await toolbox.signMessage?.(TEST_MESSAGE);
+    const signature2 = await toolbox.signMessage?.(TEST_MESSAGE);
+
+    expect(signature1).toBeDefined();
+    expect(signature2).toBeDefined();
+    expect(signature1).toBe(signature2 as string);
+  });
+
+  test("should handle signMessage when no signer is present", async () => {
+    const toolbox = await getEvmToolbox(Chain.Ethereum);
+
+    expect(toolbox.signMessage).toBeUndefined();
+  });
+
+  test("should work with different EVM chains", async () => {
+    const chains = [Chain.Ethereum, Chain.Arbitrum, Chain.Polygon, Chain.BinanceSmartChain] as const;
+
+    for (const chain of chains) {
+      const toolbox = await getEvmToolbox(chain, { phrase: TEST_PHRASE });
+      const signature = await toolbox.signMessage?.(TEST_MESSAGE);
+
+      expect(signature).toBeDefined();
+      expect(typeof signature).toBe("string");
+    }
+  });
+});

--- a/packages/toolboxes/src/evm/toolbox/baseEVMToolbox.ts
+++ b/packages/toolboxes/src/evm/toolbox/baseEVMToolbox.ts
@@ -82,7 +82,7 @@ export function BaseEVMToolbox<
     },
     isApproved: getIsApproved({ chain, provider }),
     sendTransaction: getSendTransaction({ chain, isEIP1559Compatible, provider, signer }),
-    signMessage: signer?.signMessage,
+    signMessage: signer ? (message: string | Uint8Array) => signer.signMessage(message) : undefined,
     transfer: getTransfer({ chain, isEIP1559Compatible, provider, signer }),
     validateAddress: (address: string) => evmValidateAddress({ address }),
   };


### PR DESCRIPTION
Using evm signMessage method (at least for keystore) was broken. Method was loosing this and ended up with error:

`TypeError: this.signMessageSync is not a function`
