### PR TITLE
Add monad to supported wallets

### DIFF
--- a/.changeset/rich-lies-slide.md
+++ b/.changeset/rich-lies-slide.md
@@ -1,0 +1,7 @@
+---
+"@swapkit/wallet-extensions": patch
+"@swapkit/wallet-hardware": patch
+"@swapkit/wallets": patch
+---
+
+Add monad support to wallets

--- a/packages/wallet-extensions/src/okx/index.ts
+++ b/packages/wallet-extensions/src/okx/index.ts
@@ -29,6 +29,7 @@ export const okxWallet = createWallet({
     Chain.Cosmos,
     Chain.Ethereum,
     Chain.Gnosis,
+    Chain.Monad,
     // NEAR transfer is not yet supported in OKX Wallet
     // Chain.Near,
     Chain.Optimism,

--- a/packages/wallet-extensions/src/talisman/index.ts
+++ b/packages/wallet-extensions/src/talisman/index.ts
@@ -31,6 +31,7 @@ export const talismanWallet = createWallet({
     Chain.Arbitrum,
     Chain.Avalanche,
     Chain.Base,
+    Chain.Monad,
     Chain.Polygon,
     Chain.BinanceSmartChain,
     Chain.Optimism,
@@ -84,6 +85,7 @@ async function getWalletMethods(chain: Chain) {
     case Chain.Avalanche:
     case Chain.BinanceSmartChain:
     case Chain.Base:
+    case Chain.Monad:
     case Chain.XLayer: {
       if (!(window.talismanEth && "send" in window.talismanEth)) {
         throw new SwapKitError({ errorKey: "wallet_talisman_not_found", info: { chain } });

--- a/packages/wallet-hardware/src/keepkey/index.ts
+++ b/packages/wallet-hardware/src/keepkey/index.ts
@@ -65,6 +65,7 @@ export const keepkeyWallet = createWallet({
     Chain.Dash,
     Chain.Ethereum,
     Chain.Litecoin,
+    Chain.Monad,
     Chain.Ripple,
     Chain.Optimism,
     Chain.Polygon,
@@ -96,6 +97,7 @@ async function getWalletMethods({
     case Chain.Avalanche:
     case Chain.Base:
     case Chain.Ethereum:
+    case Chain.Monad:
     case Chain.XLayer: {
       const provider = await getProvider(chain);
       const signer = new KeepKeySigner({ chain, derivationPath, provider, sdk });

--- a/packages/wallet-hardware/src/ledger/clients/evm.ts
+++ b/packages/wallet-hardware/src/ledger/clients/evm.ts
@@ -137,4 +137,5 @@ export const OptimismLedger = (params: LedgerParams) =>
 export const PolygonLedger = (params: LedgerParams) => new EVMLedgerInterface({ ...params, chainId: ChainId.Polygon });
 export const BinanceSmartChainLedger = (params: LedgerParams) =>
   new EVMLedgerInterface({ ...params, chainId: ChainId.BinanceSmartChain });
+export const MonadLedger = (params: LedgerParams) => new EVMLedgerInterface({ ...params, chainId: ChainId.Monad });
 export const XLayerLedger = (params: LedgerParams) => new EVMLedgerInterface({ ...params, chainId: ChainId.XLayer });

--- a/packages/wallet-hardware/src/ledger/helpers/getLedgerClient.ts
+++ b/packages/wallet-hardware/src/ledger/helpers/getLedgerClient.ts
@@ -9,6 +9,7 @@ import {
   BinanceSmartChainLedger,
   EthereumLedger,
   GnosisLedger,
+  MonadLedger,
   OptimismLedger,
   PolygonLedger,
   XLayerLedger,
@@ -40,6 +41,7 @@ type LedgerSignerMap = {
   [Chain.Ethereum]: ReturnType<typeof EthereumLedger>;
   [Chain.Gnosis]: ReturnType<typeof GnosisLedger>;
   [Chain.Litecoin]: ReturnType<typeof LitecoinLedger>;
+  [Chain.Monad]: ReturnType<typeof MonadLedger>;
   [Chain.Near]: ReturnType<typeof getNearLedgerClient>;
   [Chain.Optimism]: ReturnType<typeof OptimismLedger>;
   [Chain.Polygon]: ReturnType<typeof PolygonLedger>;
@@ -85,6 +87,7 @@ export const getLedgerClient = async <T extends LedgerSupportedChain>({
         Chain.BinanceSmartChain,
         Chain.Ethereum,
         Chain.Gnosis,
+        Chain.Monad,
         Chain.Optimism,
         Chain.Polygon,
         Chain.Base,
@@ -102,6 +105,7 @@ export const getLedgerClient = async <T extends LedgerSupportedChain>({
             .with(Chain.Base, () => BaseLedger(params) as LedgerSignerMap[T])
             .with(Chain.Aurora, () => AuroraLedger(params) as LedgerSignerMap[T])
             .with(Chain.Gnosis, () => GnosisLedger(params) as LedgerSignerMap[T])
+            .with(Chain.Monad, () => MonadLedger(params) as LedgerSignerMap[T])
             .with(Chain.XLayer, () => XLayerLedger(params) as LedgerSignerMap[T])
             .otherwise(() => EthereumLedger(params) as LedgerSignerMap[T]);
         },

--- a/packages/wallet-hardware/src/ledger/index.ts
+++ b/packages/wallet-hardware/src/ledger/index.ts
@@ -43,6 +43,7 @@ export const ledgerWallet = createWallet({
     Chain.Ethereum,
     Chain.Gnosis,
     Chain.Litecoin,
+    Chain.Monad,
     Chain.Near,
     Chain.Optimism,
     Chain.Polygon,
@@ -135,6 +136,7 @@ async function getWalletMethods({ chain, derivationPath }: { chain: Chain; deriv
     case Chain.Base:
     case Chain.Aurora:
     case Chain.Gnosis:
+    case Chain.Monad:
     case Chain.XLayer: {
       const { getEvmToolbox } = await import("@swapkit/toolboxes/evm");
       const signer = await getLedgerClient({ chain, derivationPath });

--- a/packages/wallet-hardware/src/trezor/index.ts
+++ b/packages/wallet-hardware/src/trezor/index.ts
@@ -42,6 +42,7 @@ async function getTrezorWallet<T extends Chain>({
     case Chain.BinanceSmartChain:
     case Chain.Ethereum:
     case Chain.Gnosis:
+    case Chain.Monad:
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.XLayer: {
@@ -336,6 +337,7 @@ export const trezorWallet = createWallet({
     Chain.Ethereum,
     Chain.Gnosis,
     Chain.Litecoin,
+    Chain.Monad,
     Chain.Optimism,
     Chain.Polygon,
     Chain.XLayer,

--- a/packages/wallets/src/walletconnect/constants.ts
+++ b/packages/wallets/src/walletconnect/constants.ts
@@ -18,6 +18,7 @@ export const NEAR_TESTNET_ID = "near:testnet";
 export const TRON_MAINNET_ID = "tron:0x2b6653dc";
 export const AURORA_MAINNET_ID = "eip155:1313161554";
 export const BERACHAIN_MAINNET_ID = "eip155:80094";
+export const MONAD_MAINNET_ID = "eip155:143";
 
 export const DEFAULT_LOGGER = "debug";
 

--- a/packages/wallets/src/walletconnect/helpers.ts
+++ b/packages/wallets/src/walletconnect/helpers.ts
@@ -11,6 +11,7 @@ import {
   ETHEREUM_MAINNET_ID,
   KUJIRA_MAINNET_ID,
   MAYACHAIN_MAINNET_ID,
+  MONAD_MAINNET_ID,
   NEAR_MAINNET_ID,
   NEAR_TESTNET_ID,
   OPTIMISM_MAINNET_ID,
@@ -41,6 +42,8 @@ export const chainToChainId = (chain: Chain) => {
       return BSC_MAINNET_ID;
     case Chain.Berachain:
       return BERACHAIN_MAINNET_ID;
+    case Chain.Monad:
+      return MONAD_MAINNET_ID;
     case Chain.Ethereum:
       return ETHEREUM_MAINNET_ID;
     case Chain.THORChain:

--- a/packages/wallets/src/walletconnect/index.ts
+++ b/packages/wallets/src/walletconnect/index.ts
@@ -77,6 +77,7 @@ export const walletconnectWallet = createWallet({
     Chain.Ethereum,
     Chain.Kujira,
     Chain.Maya,
+    Chain.Monad,
     Chain.Near,
     Chain.Optimism,
     Chain.Polygon,
@@ -110,6 +111,7 @@ async function getToolbox<T extends (typeof WC_SUPPORTED_CHAINS)[number]>({
     case Chain.Base:
     case Chain.BinanceSmartChain:
     case Chain.Ethereum:
+    case Chain.Monad:
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.XLayer: {


### PR DESCRIPTION
❌ Passkeys: No option to connect but it should work according to [Monad docs](https://docs.monad.xyz/tooling-and-infra/wallet-infra/embedded-wallets)
❌
 Bitget: wallet_chain_not_supported, Monad natively supported in Bitget, should work according to [Monad docs](https://docs.monad.xyz/tooling-and-infra/wallets/software-wallets#provider-summary)
❌
 OKX: wallet_chain_not_supported, Monad natively supported in OKX, this is still being worked on by Monad it seems (status = in progress on docs)
❌
 Talisman: wallet_chain_not_supported, No native support but added it same way as Ctrl & Metamask, should work
❌
 WalletConnect: This does not support Monad yet according to WalletConnect docs
❌
 TrustWallet mobile: wallet_chain_not_supported, I don't even get a QR to test. TrustWallet has native Monad support, should work according to [Monad docs](https://docs.monad.xyz/tooling-and-infra/wallets/software-wallets#provider-summary)
❌
 Coinbase wallet (mobile): wallet_chain_not_supported, Monad not natively supported. I can try adding custom network but we'd need to get rid of the chain not supported error first to be able to test
❌
 Ledger: wallet_chain_not_supported, should work through Ethereum app like it does in [Ledger Live](https://support.ledger.com/en/article/monad-mon)
❌
 Trezor: wallet_chain_not_supported, I could not find any specifics about support for it online nor can I find it in Trezor Suite
❌
 KeepKey:  wallet_chain_not_supported, I could not find any specifics about support for it online, will ask Highlander to verify