### PR TITLE
Add Vultisig TRON + Fix Vultisig cosmos

### DIFF
--- a/.changeset/khaki-owls-trade.md
+++ b/.changeset/khaki-owls-trade.md
@@ -1,0 +1,6 @@
+---
+"@swapkit/helpers": patch
+"@swapkit/wallet-extensions": patch
+---
+
+Adds support for TRON in Vultisig and fixes Cosmos

--- a/packages/helpers/src/modules/swapKitError.ts
+++ b/packages/helpers/src/modules/swapKitError.ts
@@ -246,6 +246,9 @@ const errorCodes = {
   wallet_vultisig_contract_address_not_provided: 22102,
   wallet_vultisig_asset_not_defined: 22103,
   wallet_vultisig_send_transaction_no_address: 22104,
+  wallet_vultisig_locked: 22105,
+  wallet_vultisig_no_accounts: 22106,
+  wallet_vultisig_transaction_failed: 22107,
 
   /**
    * Wallets - Xaman

--- a/packages/wallet-extensions/src/types.ts
+++ b/packages/wallet-extensions/src/types.ts
@@ -62,6 +62,7 @@ declare global {
       polkadot: Eip1193Provider;
       ripple: Eip1193Provider;
       dash: Eip1193Provider;
+      tron: TronLinkWindow;
       zcash: Eip1193Provider;
     };
 

--- a/packages/wallet-extensions/src/vultisig/index.ts
+++ b/packages/wallet-extensions/src/vultisig/index.ts
@@ -76,6 +76,7 @@ export const vultisigWallet = createWallet({
     Chain.Ripple,
     Chain.Solana,
     Chain.THORChain,
+    Chain.Tron,
     Chain.Zcash,
     Chain.XLayer,
   ],
@@ -169,6 +170,35 @@ async function getWalletMethods(chain: (typeof VULTISIG_SUPPORTED_CHAINS)[number
       const { getSubstrateToolbox } = await import("@swapkit/toolboxes/substrate");
       const toolbox = await getSubstrateToolbox(chain as SubstrateChain);
       return { ...toolbox, transfer: walletTransfer };
+    })
+
+    .with(Chain.Tron, async () => {
+      const { createTronToolbox } = await import("@swapkit/toolboxes/tron");
+      const tronProvider = window.vultisig?.tron;
+      if (!tronProvider) throw new SwapKitError("wallet_vultisig_not_found");
+
+      const response = await tronProvider.request({ method: "tron_requestAccounts" });
+      if (response === "") {
+        throw new SwapKitError("wallet_vultisig_locked", {
+          message: "Vultisig is locked. Please unlock it to continue.",
+        });
+      }
+
+      const address = tronProvider.tronWeb?.defaultAddress?.base58;
+      if (!address) {
+        throw new SwapKitError("wallet_vultisig_no_accounts", { chain: Chain.Tron });
+      }
+
+      const signer = {
+        getAddress: async () => address,
+        signTransaction: async (transaction: any) => {
+          return await tronProvider.tronWeb.trx.sign(transaction);
+        },
+      };
+
+      const toolbox = await createTronToolbox({ signer });
+
+      return { ...toolbox, address };
     })
 
     .otherwise(async () => null);

--- a/packages/wallet-extensions/src/vultisig/walletHelpers.ts
+++ b/packages/wallet-extensions/src/vultisig/walletHelpers.ts
@@ -18,6 +18,7 @@ import type { getCosmosToolbox } from "@swapkit/toolboxes/cosmos";
 import type { ApproveParams, CallParams, EVMTxParams } from "@swapkit/toolboxes/evm";
 import type { SolanaProvider } from "@swapkit/toolboxes/solana";
 import type { BrowserProvider, Eip1193Provider } from "ethers";
+import type { TronLinkWindow } from "../tronlink/types";
 import type { VultisigCosmosProvider } from "../types";
 
 type TransactionMethod = "send_transaction" | "deposit_transaction";
@@ -46,9 +47,11 @@ type VultisigProviderType<T> = T extends typeof Chain.Solana
     ? VultisigCosmosProvider
     : T extends EVMChain
       ? Eip1193Provider
-      : T extends typeof Chain.Maya | typeof Chain.THORChain | typeof Chain.Ripple | typeof Chain.Polkadot | UTXOChain
-        ? Eip1193Provider
-        : undefined;
+      : T extends typeof Chain.Tron
+        ? TronLinkWindow
+        : T extends typeof Chain.Maya | typeof Chain.THORChain | typeof Chain.Ripple | typeof Chain.Polkadot | UTXOChain
+          ? Eip1193Provider
+          : undefined;
 
 export async function getVultisigProvider<T extends Chain>(chain: T): Promise<VultisigProviderType<T>> {
   if (!window.vultisig) throw new SwapKitError("wallet_vultisig_not_found");
@@ -67,6 +70,7 @@ export async function getVultisigProvider<T extends Chain>(chain: T): Promise<Vu
     .with(Chain.Maya, () => window.vultisig?.mayachain as Eip1193Provider)
     .with(Chain.Polkadot, () => window.vultisig?.polkadot as Eip1193Provider)
     .with(Chain.Ripple, () => window.vultisig?.ripple as Eip1193Provider)
+    .with(Chain.Tron, () => window.vultisig?.tron as TronLinkWindow)
     .with(Chain.Zcash, () => window.vultisig?.zcash as Eip1193Provider)
     .otherwise(() => undefined) as VultisigProviderType<T>;
 }
@@ -115,11 +119,11 @@ export async function getVultisigAddress(chain: Chain) {
       await windowProvider.request({ method: "wallet_switch_chain", params: [{ chainId }] });
 
       let account = await windowProvider.request({ method: "get_accounts" });
-      if (!account) {
+      if (!account || (Array.isArray(account) && account.length === 0)) {
         const connectedAcount = await windowProvider.request({ method: "request_accounts" });
         account = connectedAcount[0].address;
       }
-      return account;
+      return Array.isArray(account) ? account[0] : account;
     }
 
     if (EVMChains.includes(chain as EVMChain)) {
@@ -134,6 +138,33 @@ export async function getVultisigAddress(chain: Chain) {
 
       const accounts = await solanaProvider.connect();
       return accounts.publicKey.toString();
+    }
+
+    if (chain === Chain.Tron) {
+      const tronProvider = (await getVultisigProvider(Chain.Tron)) as TronLinkWindow;
+      if (!tronProvider) {
+        throw new SwapKitError({
+          errorKey: "wallet_provider_not_found",
+          info: { chain, wallet: WalletOption.VULTISIG },
+        });
+      }
+
+      const response = await tronProvider.request({ method: "tron_requestAccounts" });
+      if (response === "") {
+        throw new SwapKitError("wallet_vultisig_locked", {
+          message: "Vultisig is locked. Please unlock it to continue.",
+        });
+      }
+
+      const address = tronProvider.tronWeb?.defaultAddress?.base58;
+      if (!address) {
+        throw new SwapKitError({
+          errorKey: "wallet_provider_not_found",
+          info: { chain, wallet: WalletOption.VULTISIG },
+        });
+      }
+
+      return address;
     }
 
     const accounts = await windowProvider.request({ method: "request_accounts", params: [] });


### PR DESCRIPTION

**Adds support for TRON**: 

- Tested: transfer of TRX
- Tested: transfer TRX.USDT
- Tested: swapping TRX → BSC 

All tests from the Vite playground. A workaround was required for the `expiration` field because the Vite playground does not set this parameter correctly for TRON. As a result, all transactions fail due to being considered expired. The same issue also occurs with TronLink, so it does not appear to be related to Vultisig. When the `expiration` field is properly set, everything works as expected.

**Fixes the Cosmos `getAddress` function**. 

Despite this fix, there is also an ongoing fix on the Vultisig side related to the `wallet_switch_chain` method. https://github.com/vultisig/vultisig-windows/pull/3234. This issue is already fixed and will be included in Vultisig extension release **0.2.13**.