### PR TITLE
fix(keepkey, ledger): add Berachain and Gnosis chain support

### DIFF
--- a/packages/wallet-hardware/src/keepkey/index.ts
+++ b/packages/wallet-hardware/src/keepkey/index.ts
@@ -57,6 +57,7 @@ export const keepkeyWallet = createWallet({
     Chain.Arbitrum,
     Chain.Avalanche,
     Chain.Base,
+    Chain.Berachain,
     Chain.BinanceSmartChain,
     Chain.Bitcoin,
     Chain.BitcoinCash,
@@ -64,6 +65,7 @@ export const keepkeyWallet = createWallet({
     Chain.Dogecoin,
     Chain.Dash,
     Chain.Ethereum,
+    Chain.Gnosis,
     Chain.Litecoin,
     Chain.Monad,
     Chain.Ripple,
@@ -92,6 +94,8 @@ async function getWalletMethods({
   switch (chain) {
     case Chain.BinanceSmartChain:
     case Chain.Arbitrum:
+    case Chain.Berachain:
+    case Chain.Gnosis:
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.Avalanche:

--- a/packages/wallet-hardware/src/ledger/index.ts
+++ b/packages/wallet-hardware/src/ledger/index.ts
@@ -34,6 +34,7 @@ export const ledgerWallet = createWallet({
     Chain.Aurora,
     Chain.Avalanche,
     Chain.Base,
+    Chain.Berachain,
     Chain.BinanceSmartChain,
     Chain.Bitcoin,
     Chain.BitcoinCash,
@@ -130,6 +131,7 @@ async function getWalletMethods({ chain, derivationPath }: { chain: Chain; deriv
     case Chain.Ethereum:
     case Chain.Avalanche:
     case Chain.Arbitrum:
+    case Chain.Berachain:
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.BinanceSmartChain:


### PR DESCRIPTION
- Add `Chain.Berachain` and `Chain.Gnosis` to KeepKey's `supportedChains` array and EVM switch case
- Add `Chain.Berachain` to Ledger's `supportedChains` array and EVM switch case
- All are standard EVM chains handled by existing chain-agnostic signers — no additional changes needed