### PR TITLE
fix(ledger): add Berachain chain support

### DIFF
--- a/packages/wallet-hardware/src/ledger/index.ts
+++ b/packages/wallet-hardware/src/ledger/index.ts
@@ -34,6 +34,7 @@ export const ledgerWallet = createWallet({
     Chain.Aurora,
     Chain.Avalanche,
     Chain.Base,
+    Chain.Berachain,
     Chain.BinanceSmartChain,
     Chain.Bitcoin,
     Chain.BitcoinCash,
@@ -130,6 +131,7 @@ async function getWalletMethods({ chain, derivationPath }: { chain: Chain; deriv
     case Chain.Ethereum:
     case Chain.Avalanche:
     case Chain.Arbitrum:
+    case Chain.Berachain:
     case Chain.Optimism:
     case Chain.Polygon:
     case Chain.BinanceSmartChain:


### PR DESCRIPTION
- Add `Chain.Berachain` to Ledger's `supportedChains` array and EVM switch case
- FRT-1786 was marked Done but BERA was still missing from the SDK source